### PR TITLE
Add reveal ad with temporary adjustment to trigger faked creative

### DIFF
--- a/packages/global/browser/index.js
+++ b/packages/global/browser/index.js
@@ -6,6 +6,24 @@ const RevealAdHandler = () => import(/* webpackChunkName: "reveal-ad-handler" */
 
 export default (Browser) => {
   MonoRail(Browser);
+  // ### HACK ### to get Reveal ad to display on all pages
+  const { EventBus } = Browser;
+  // console.log('EventBus: ', EventBus.$on);
+  EventBus.$on('revealAdListenerAdded', () => {
+    console.warn('hitting on loaded stuff');
+    const reskinVars = {
+      adTitle: 'CLICK HERE FOR MORE INFORMATION',
+      adClickUrl: '#',
+      adImagePath: 'https://img.labpulse.com/files/base/smg/all/image/static/lab/reveal-ad/sample-300x250.png',
+      backgroundImagePath: 'https://img.labpulse.com/files/base/smg/all/image/static/lab/reveal-ad/sample-bg.jpg',
+      background: 'transparent',
+    };
+    window.postMessage(JSON.stringify(reskinVars), '*');
+  });
+  Browser.register('RevealAdHandler', RevealAdHandler, {
+    provide: { EventBus },
+  });
+  // will need to also remove the inclusion and event trigger in the reveal ad once configured
+  // ### HACK ###
   Browser.register('ContentMeterTrack', ContentMeterTrack);
-  Browser.register('RevealAdHandler', RevealAdHandler);
 };

--- a/packages/global/browser/reveal-ad-handler.vue
+++ b/packages/global/browser/reveal-ad-handler.vue
@@ -28,6 +28,8 @@ const rel = 'noopener noreferrer';
 const { warn } = console;
 
 export default {
+  inject: ['EventBus'],
+
   props: {
     id: {
       type: String,
@@ -72,6 +74,7 @@ export default {
     }
 
     window.addEventListener('message', this.listener);
+    this.EventBus.$emit('revealAdListenerAdded', {});
     googletag.cmd.push(() => {
       const slot = googletag.defineOutOfPageSlot(this.path, this.id).addService(googletag.pubads());
       const div = document.createElement('div');

--- a/packages/global/components/layouts/content/wrapper.marko
+++ b/packages/global/components/layouts/content/wrapper.marko
@@ -15,12 +15,12 @@ $ const alias = get(input, "primarySection.alias");
       <marko-web-p1-events-track-content node=content />
     </marko-web-resolve-page>
   </@head>
-  <!-- <@above-container>
-    <marko-web-resolve-page|{ data: content }| node=pageNode>
-      $ const aliases = hierarchyAliases(content.primarySection);
-      <global-reveal-ad-handler select-all-targets=true path=GAM.getAdUnit({ name: "reskin", aliases }).path id="reveal-ad" />
+   <@above-container>
+    <marko-web-resolve-page|{ data: section }| node=pageNode>
+      $ const aliases = hierarchyAliases(section);
+      <theme-reveal-ad-handler select-all-targets=true path=GAM.getAdUnit({ name: "reskin", aliases }).path id="reveal-ad" />
     </marko-web-resolve-page>
-  </@above-container> -->
+  </@above-container>
   <@page>
     <marko-web-resolve-page|{ data: content }| node=pageNode>
       $ const aliases = hierarchyAliases(content.primarySection);

--- a/packages/global/components/layouts/website-section/default.marko
+++ b/packages/global/components/layouts/website-section/default.marko
@@ -15,6 +15,12 @@ $ const { GAM } = out.global;
     </marko-web-resolve-page>
     <${input.head} />
   </@head>
+  <@above-container>
+    <marko-web-resolve-page|{ data: section }| node=pageNode>
+      $ const aliases = hierarchyAliases(section);
+      <theme-reveal-ad-handler select-all-targets=true path=GAM.getAdUnit({ name: "reskin", aliases }).path id="reveal-ad" />
+    </marko-web-resolve-page>
+  </@above-container>
   <@page>
     <marko-web-resolve-page|{ data: section }| node=pageNode>
       $ const aliases = hierarchyAliases(section);

--- a/packages/global/package.json
+++ b/packages/global/package.json
@@ -25,6 +25,7 @@
     "@parameter1/base-cms-marko-web-omeda": "^2.103.0",
     "@parameter1/base-cms-marko-web-omeda-identity-x": "^2.105.0",
     "@parameter1/base-cms-marko-web-p1-events": "^2.77.0",
+    "@parameter1/base-cms-marko-web-reveal-ad": "^2.75.1",
     "@parameter1/base-cms-marko-web-search": "^2.80.0",
     "@parameter1/base-cms-marko-web-social-sharing": "^2.92.0",
     "@parameter1/base-cms-marko-web-theme-default": "^2.96.0",

--- a/packages/global/scss/components/_ads.scss
+++ b/packages/global/scss/components/_ads.scss
@@ -1,7 +1,12 @@
 // Prevent Reveal Ad from causing CLS
 // @TODO determin if this should be moved to @parameter1/base-cms-marko-web
+
 #marko-web-reveal-ad-handler {
   display: none;
+  // remove white default bg to allow for bg image to display correctly
+   ~ .document-container {
+    background-color: transparent;;
+   }
 }
 .reveal-ad {
   height: 298px;

--- a/packages/global/scss/components/_ads.scss
+++ b/packages/global/scss/components/_ads.scss
@@ -1,0 +1,24 @@
+// Prevent Reveal Ad from causing CLS
+// @TODO determin if this should be moved to @parameter1/base-cms-marko-web
+#marko-web-reveal-ad-handler {
+  display: none;
+}
+.reveal-ad {
+  height: 298px;
+}
+body .document-container > .page:first-of-type {
+  margin-top: 298px;
+  // excluded the following page types as they dont use reskin ads
+  &.page--search,
+  &.page--authenticate,
+  &.page--login,
+  &.page--logout,
+  &.page--profile,
+  &.page--register {
+    margin-top: 60px;
+    margin-bottom: 60px;
+  }
+}
+body .document-container > .reveal-ad + .page {
+  margin-top: 0;
+}

--- a/packages/global/scss/core.scss
+++ b/packages/global/scss/core.scss
@@ -6,6 +6,7 @@
 @import "../../node_modules/@parameter1/base-cms-marko-web-reveal-ad/scss/reveal-ad";
 
 // skin components
+@import "./components/ads";
 @import "./components/content-meter";
 @import "./components/site-navbar";
 @import "./components/site-navbar-c";

--- a/packages/global/scss/core.scss
+++ b/packages/global/scss/core.scss
@@ -3,6 +3,7 @@
 
 // import theme css
 @import "../../node_modules/@parameter1/base-cms-marko-web-theme-monorail/scss/core";
+@import "../../node_modules/@parameter1/base-cms-marko-web-reveal-ad/scss/reveal-ad";
 
 // skin components
 @import "./components/content-meter";

--- a/yarn.lock
+++ b/yarn.lock
@@ -2376,6 +2376,14 @@
     http-errors "^1.8.0"
     node-fetch "^2.6.1"
 
+"@parameter1/base-cms-marko-web-reveal-ad@^2.75.1":
+  version "2.75.1"
+  resolved "https://registry.yarnpkg.com/@parameter1/base-cms-marko-web-reveal-ad/-/base-cms-marko-web-reveal-ad-2.75.1.tgz#6df390011c4d6d109d86645ccca5d768a9ec0f46"
+  integrity sha512-wcT2R0HE84QZs6x18j5Fi0GgPL0wrX9McskGPnsEUveCwI22FTMY045N2BZS/+9MDy52FE0L9UBk173Yeg4+Mw==
+  dependencies:
+    "@parameter1/base-cms-object-path" "^2.75.1"
+    "@parameter1/base-cms-utils" "^2.75.1"
+
 "@parameter1/base-cms-marko-web-search@^2.80.0":
   version "2.80.0"
   resolved "https://registry.yarnpkg.com/@parameter1/base-cms-marko-web-search/-/base-cms-marko-web-search-2.80.0.tgz#f5e16de00475ca946e1d0aeaab00bbbe69e4e4ba"


### PR DESCRIPTION
Added the inclusion of the revealAd package and imported css items.  

I also setup the components to reference `<theme-reveal-ad-handler>` assuming all of this should be added to the monorail theme and get removed from this repo.  That said, this would be a good time to remove the hack added in order to get this to fire without having a gam configured correctly in the container.  At the moment it is faking the post message that actually triggers this ad.  See /browser/index.js & browser/reveal-ad-handler.vue for a better explination, but in short the vue component is emitting a specific event once it is ready to listen for the message.  Which the hack added to the index file is listening for that event and then sending the message with the reveal ad info in it.  
<img width="1609" alt="Screen Shot 2022-08-11 at 11 13 25 AM" src="https://user-images.githubusercontent.com/3845869/184181654-360b0b0b-3ff0-4810-88b5-b6fe14352ade.png">
<img width="1424" alt="Screen Shot 2022-08-11 at 11 13 36 AM" src="https://user-images.githubusercontent.com/3845869/184181677-1f6f19ec-60cd-4a51-b4c9-352452147ee4.png">
 
<img width="1325" alt="Screen Shot 2022-08-11 at 11 13 44 AM" src="https://user-images.githubusercontent.com/3845869/184181683-3515b1a2-6766-461d-b351-adda0d8fd01c.png">

