### PR TITLE
Update nativeX config to use smg  domain and LP default placement

### DIFF
--- a/packages/global/components/blocks/most-popular-list.marko
+++ b/packages/global/components/blocks/most-popular-list.marko
@@ -58,6 +58,7 @@ $ const buildContentQuery = () => {
       $ const ordered = ids.map(id => map.get(`${id}`)).filter(id => id);
       <if(ordered.length)>
         <theme-latest-content-list-block nodes=ordered title="Most Popular" class=input.class>
+          <@native-x indexes=[0] name="default" aliases=[] />
           <@node display-image=false />
         </theme-latest-content-list-block>
       </if>
@@ -65,6 +66,7 @@ $ const buildContentQuery = () => {
   </if>
   <else>
     <theme-latest-content-list-block alias="home" title="Most Popular" class=input.class>
+      <@native-x indexes=[0] name="default" aliases=[] />
       <@node display-image=false />
     </theme-latest-content-list-block>
   </else>

--- a/packages/global/components/blocks/most-popular-list.marko
+++ b/packages/global/components/blocks/most-popular-list.marko
@@ -58,7 +58,6 @@ $ const buildContentQuery = () => {
       $ const ordered = ids.map(id => map.get(`${id}`)).filter(id => id);
       <if(ordered.length)>
         <theme-latest-content-list-block nodes=ordered title="Most Popular" class=input.class>
-          <@native-x indexes=[0] name="default" aliases=[] />
           <@node display-image=false />
         </theme-latest-content-list-block>
       </if>
@@ -66,7 +65,6 @@ $ const buildContentQuery = () => {
   </if>
   <else>
     <theme-latest-content-list-block alias="home" title="Most Popular" class=input.class>
-      <@native-x indexes=[0] name="default" aliases=[] />
       <@node display-image=false />
     </theme-latest-content-list-block>
   </else>

--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -226,6 +226,7 @@ $ const shouldInjectAds = ["article", "video", "news", "podcast"].includes(type)
       content-id=content.id
       section-id=content.primarySection.id
       published=content.published
+      with-native-x=true
     />
   </@section>
 

--- a/packages/global/components/layouts/website-section/home.marko
+++ b/packages/global/components/layouts/website-section/home.marko
@@ -108,7 +108,9 @@ $ const promise = websiteSectionContentLoader(apollo, {
                   </if>
                 </div>
                 <div class="col-lg-4 page-rail">
-                  <theme-latest-content-list-block nodes=standard.nodes title=rightRailHeader />
+                  <theme-latest-content-list-block nodes=standard.nodes title=rightRailHeader >
+                    <@native-x indexes=[0] name="default" aliases=aliases />
+                  </theme-latest-content-list-block>
                   <!-- <global-video-player /> -->
                 </div>
               </div>

--- a/packages/global/config/native-x.js
+++ b/packages/global/config/native-x.js
@@ -1,6 +1,6 @@
 const NativeXConfiguration = require('@parameter1/base-cms-marko-web-native-x/config');
 
 module.exports = ({
-  uri = 'https://randallreilly.native-x.parameter1.com',
+  uri = 'https://smg.native-x.parameter1.com',
   enabled = false,
 } = {}) => new NativeXConfiguration(uri, { enabled });

--- a/sites/labpulse.com/config/native-x.js
+++ b/sites/labpulse.com/config/native-x.js
@@ -2,11 +2,11 @@ const configureNativeX = require('@science-medicine-group/package-global/config/
 
 const config = configureNativeX();
 
-config.enabled = false;
+config.enabled = true;
 
 config
   .setAliasPlacements('default', [
-    { name: 'default', id: 'NOT_SET' },
+    { name: 'default', id: '62fbe63cd7b5c2000172a0aa' },
   ]);
 
 module.exports = config;

--- a/sites/scienceboard.net/config/native-x.js
+++ b/sites/scienceboard.net/config/native-x.js
@@ -6,7 +6,7 @@ config.enabled = false;
 
 config
   .setAliasPlacements('default', [
-    { name: 'default', id: 'NOT_SET' },
+    { name: 'default', id: '62fbf200d7b5c2000172a1e4' },
   ]);
 
 module.exports = config;


### PR DESCRIPTION
**@todo:** Figure out how to get the section-feed-wrapper & section-feed block to support nativeX.

At the moment this is an update to use https://smg.native-x.parameter1.com & default placement id for labPulse.  At the moment labPulse is the only publisher setup in nativeX.  Waiting to figure out if we will need to setup specific placements for the specific slots.  

At the moment it is pulling the default placement into top right of home/section pages along with top slot of most popular.  It also pulls into top slot of related content and last card slot of related content.  
### Content pages(Top slot `Latest` & Last card of `Related Content`):
![Screen Shot 2022-08-16 at 2 07 58 PM](https://user-images.githubusercontent.com/3845869/184963078-bc8910fc-f892-4207-a281-33019a0eca1b.png)
![Screen Shot 2022-08-16 at 2 07 48 PM](https://user-images.githubusercontent.com/3845869/184962985-ac2b2837-ccaf-433c-8e79-5f9e2937db75.png)

### Home page(top slot of `Latest News`):
![Screen Shot 2022-08-16 at 11 45 08 AM](https://user-images.githubusercontent.com/3845869/184963196-b24ab6d2-c2d9-46fb-bb87-0729b68643b6.png)


