### PR TITLE
Fix pagination in section feed wrapper & fix spreading of queryParams props

### DIFF
--- a/packages/global/components/wrappers/section-feed.marko
+++ b/packages/global/components/wrappers/section-feed.marko
@@ -11,7 +11,7 @@ $ const queryParams = {
 <div class="row">
   <div class="col-lg-8">
     <theme-section-feed-block alias=input.alias header=input.header>
-      <@query-params limit=3 query-params=queryParams />
+      <@query-params ...queryParams limit=3 skip=p.skip({ perPage })/>
       <@node-list innerJustified=false ...input.nodeList />
     </theme-section-feed-block>
     <theme-gam-define-display-ad
@@ -21,7 +21,7 @@ $ const queryParams = {
       modifiers=["inline-section-feed"]
     />
     <theme-section-feed-block alias=input.alias>
-      <@query-params limit=3 skip=p.skip({ perPage, skip: 3 }) query-params=queryParams />
+      <@query-params ...queryParams limit=3 skip=p.skip({ perPage, skip: 3 }) />
       <@node-list innerJustified=false ...input.nodeList />
     </theme-section-feed-block>
     <theme-gam-define-display-ad
@@ -38,7 +38,7 @@ $ const queryParams = {
 <div class="row">
   <div class="col-lg-8">
     <theme-section-feed-block alias=input.alias>
-      <@query-params limit=3 skip=p.skip({ perPage, skip: 6 }) query-params=queryParams />
+      <@query-params ...queryParams limit=3 skip=p.skip({ perPage, skip: 6 }) />
       <@node-list innerJustified=false ...input.nodeList />
     </theme-section-feed-block>
     <!--   -->
@@ -49,7 +49,7 @@ $ const queryParams = {
       modifiers=["inline-section-feed"]
     />
     <theme-section-feed-block alias=input.alias>
-      <@query-params limit=3 skip=p.skip({ perPage, skip: 9 }) query-params=queryParams />
+      <@query-params ...queryParams limit=3 skip=p.skip({ perPage, skip: 9 }) />
       <@node-list innerJustified=false ...input.nodeList />
     </theme-section-feed-block>
     <if(withPagination)>


### PR DESCRIPTION
The first query-params call was missing the skip to account for perPage skip so it was always showing the first three items instead of the first three items after pageX was skipped.

I spread queryParams instead of setting query-params=queryPrams as the later was sending the queryParams prop with its own nested queryParams.queryParams.

<img width="1420" alt="Screen Shot 2022-08-17 at 11 16 12 AM" src="https://user-images.githubusercontent.com/3845869/185190748-bec05c9d-79c8-4b3b-bdb6-c24c3b23189b.png">

