### PR TITLE
Set user nav items directly instead of contextually

### DIFF
--- a/packages/global/components/site-header-c.marko
+++ b/packages/global/components/site-header-c.marko
@@ -18,7 +18,6 @@ $ const navigation = {
   primary: getNavItems("primary.items"),
   secondary: getNavItems("secondary.items"),
   tertiary: getNavItems("tertiary.items"),
-  user: getNavItems("user.items"),
 };
 
 <marko-web-block
@@ -63,7 +62,7 @@ $ const navigation = {
         />
       </if> -->
       <default-theme-site-navbar-items
-        items=navigation.user
+        items=site.getAsArray("navigation.user.items")
         modifiers=["user"]
         reg-enabled=input.regEnabled
         has-user=input.hasUser


### PR DESCRIPTION
Get user items directly from the site config instead of using the getNavItems function which uses the contextual logic.
<img width="1137" alt="Screen Shot 2022-09-12 at 11 32 39 AM" src="https://user-images.githubusercontent.com/3845869/189707825-2bb858d2-b98d-4585-81fe-e9f8f62ab7fa.png">
