### PR TITLE
Update event content landing page

### DIFF
--- a/packages/global/components/layouts/content/contact-details/index.marko
+++ b/packages/global/components/layouts/content/contact-details/index.marko
@@ -1,0 +1,98 @@
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
+import { getAsArray, getAsObject } from "@parameter1/base-cms-object-path";
+
+$ const blockName = defaultValue(input.blockName, "page-contact-details");
+
+$ const content = getAsObject(input, "obj");
+$ const modifiers = [ ...getAsArray(input, "modifiers"), content.type];
+$ const showEmail = input.showEmail != null ? input.showEmail : true;
+
+$ const addressFields = ["address1", "address2", "cityStateZip", "country"];
+$ const showAddress = addressFields.some(k => content[k]);
+
+$ const phoneFields = ["phone", "fax", "mobile", "tollfree"];
+$ const showPhones = phoneFields.some(k => content[k]);
+
+$ const socialLinks = getAsArray(content, "socialLinks");
+$ const showSocial = socialLinks.length;
+
+$ const fields = ["title", "website"];
+$ if (showEmail) fields.push("publicEmail");
+$ const showFields = fields.some(k => content[k]);
+
+$ const websiteLinkAttrs = getAsObject(input, "websiteLinkAttrs");
+$ const socialLinkAttrs = getAsObject(input, "socialLinkAttrs");
+
+$ const lang = input.lang || "en";
+
+<marko-web-block
+  tag=input.tag
+  class=input.class
+  modifiers=modifiers
+  attrs=input.attrs
+  name="page-contact-details"
+>
+  <if(showAddress)>
+    <global-content-contact-details-section block-name=blockName>
+      <address class=`${blockName}__address`>
+        <marko-web-content-address1 block-name=blockName obj=content />
+        <marko-web-content-address2 block-name=blockName obj=content />
+        <marko-web-content-city-state-zip block-name=blockName obj=content />
+        <marko-web-content-country block-name=blockName obj=content />
+      </address>
+    </global-content-contact-details-section>
+  </if>
+
+  <if(showFields)>
+    <global-content-contact-details-section block-name=blockName>
+      <marko-web-content-title block-name=blockName obj=content />
+      <if(showEmail)>
+        <marko-web-content-public-email block-name=blockName obj=content link=true/>
+      </if>
+      <marko-web-content-website block-name=blockName obj=content link={ attrs: websiteLinkAttrs } />
+    </global-content-contact-details-section>
+  </if>
+
+  <if(showSocial)>
+    <global-content-contact-details-section block-name=blockName modifiers=["social-links"]>
+      <for|item| of=socialLinks>
+        <theme-social-follow
+          label=item.label
+          provider=item.provider
+          href=item.url
+          modifiers=["dark", "lg"]
+          attrs=socialLinkAttrs
+        />
+      </for>
+    </global-content-contact-details-section>
+  </if>
+
+  <if(showPhones)>
+    <global-content-contact-details-section block-name=blockName>
+      <if(content.phone)>
+        <div class=`${blockName}__field`>
+          <span class=`${blockName}__label`>Phone:</span>
+          <marko-web-content-phone block-name=blockName obj=content />
+        </div>
+      </if>
+      <if(content.mobile)>
+        <div class=`${blockName}__field`>
+          <span class=`${blockName}__label`>Mobile:</span>
+          <marko-web-content-mobile block-name=blockName obj=content />
+        </div>
+      </if>
+      <if(content.tollfree)>
+        <div class=`${blockName}__field`>
+          <span class=`${blockName}__label`>Tollfree:</span>
+          <marko-web-content-tollfree block-name=blockName obj=content />
+        </div>
+      </if>
+      <if(content.fax)>
+        <div class=`${blockName}__field`>
+          <span class=`${blockName}__label`>Fax:</span>
+          <marko-web-content-fax block-name=blockName obj=content />
+        </div>
+      </if>
+    </global-content-contact-details-section>
+  </if>
+</marko-web-block>

--- a/packages/global/components/layouts/content/contact-details/marko.json
+++ b/packages/global/components/layouts/content/contact-details/marko.json
@@ -1,0 +1,27 @@
+{
+  "<global-content-contact-details>": {
+    "template": "./index.marko",
+    "@obj": "object",
+    "@show-email": {
+      "type": "boolean",
+      "default-value": true
+    },
+    "@tag": {
+      "type": "string",
+      "default-value": "div"
+    },
+    "@class": "string",
+    "@modifiers": "array",
+    "@attrs": "object",
+    "@website-link-attrs": "object",
+    "@social-link-attrs": "object",
+    "@lang": "string"
+  },
+  "<global-content-contact-details-section>": {
+    "template": "./section.marko",
+    "@block-name": "string",
+    "@tag": "string",
+    "@modifiers": "array",
+    "@attrs": "object"
+  }
+}

--- a/packages/global/components/layouts/content/contact-details/section.marko
+++ b/packages/global/components/layouts/content/contact-details/section.marko
@@ -1,0 +1,9 @@
+<marko-web-element
+  block-name=input.blockName
+  name="section"
+  tag=input.tag
+  modifiers=input.modifiers
+  attrs=input.attrs
+>
+  <${input.renderBody} />
+</marko-web-element>

--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -34,7 +34,9 @@ $ const shouldInjectAds = ["article", "video", "news", "podcast"].includes(type)
       <if(type === "event")>
         <default-theme-page-dates|{ blockName }|>
           <marko-web-content-starts tag="span" block-name=blockName obj=content />
-          <marko-web-content-ends tag="span" block-name=blockName obj=content />
+          <if(content.starts !== content.ends)>
+            <marko-web-content-ends tag="span" block-name=blockName obj=content />
+          </if>
         </default-theme-page-dates>
       </if>
       <else-if(displayPublishedDate && authors.length !== 1)>

--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -50,8 +50,8 @@ $ const shouldInjectAds = ["article", "video", "news", "podcast"].includes(type)
     $ const { primarySection } = content;
     <div class="row">
       <div class="col-lg-8">
+        <global-content-contact-details obj=content />
         <div class="content-page-body">
-          <global-content-contact-details obj=content />
           <default-theme-page-contents|{ blockName }| attrs={ "data-gallery-id": id }>
             <if(content.embedCode)>
               $ const iframeContent = contentIframe(content);

--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -31,11 +31,17 @@ $ const shouldInjectAds = ["article", "video", "news", "podcast"].includes(type)
           <default-theme-content-attribution obj=content elements=["authors"] />
         </else-if>
       </if>
-      <if(displayPublishedDate && authors.length !== 1)>
+      <if(type === "event")>
+        <default-theme-page-dates|{ blockName }|>
+          <marko-web-content-start-date block-name=blockName obj=content />
+          <marko-web-content-end-date block-name=blockName obj=content />
+        </default-theme-page-dates>
+      </if>
+      <else-if(displayPublishedDate && authors.length !== 1)>
         <default-theme-page-dates|{ blockName }|>
           <theme-content-published-node block-name=blockName obj=content display-updated-date=false />
         </default-theme-page-dates>
-      </if>
+      </else-if>
       <global-sponsored-section-logo alias=primarySection.alias modifiers=["content-page"] class="mt-3" />
     </div>
   </@section>
@@ -45,6 +51,7 @@ $ const shouldInjectAds = ["article", "video", "news", "podcast"].includes(type)
     <div class="row">
       <div class="col-lg-8">
         <div class="content-page-body">
+          <global-content-contact-details obj=content />
           <default-theme-page-contents|{ blockName }| attrs={ "data-gallery-id": id }>
             <if(content.embedCode)>
               $ const iframeContent = contentIframe(content);

--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -33,8 +33,8 @@ $ const shouldInjectAds = ["article", "video", "news", "podcast"].includes(type)
       </if>
       <if(type === "event")>
         <default-theme-page-dates|{ blockName }|>
-          <marko-web-content-start-date block-name=blockName obj=content />
-          <marko-web-content-end-date block-name=blockName obj=content />
+          <marko-web-content-starts tag="span" block-name=blockName obj=content />
+          <marko-web-content-ends tag="span" block-name=blockName obj=content />
         </default-theme-page-dates>
       </if>
       <else-if(displayPublishedDate && authors.length !== 1)>

--- a/packages/global/components/layouts/content/marko.json
+++ b/packages/global/components/layouts/content/marko.json
@@ -1,4 +1,7 @@
 {
+  "taglib-imports": [
+    "./contact-details/marko.json"
+  ],
   "<global-content-default-layout>": {
     "template": "./default.marko",
     "<after-body>": {},

--- a/packages/global/scss/core.scss
+++ b/packages/global/scss/core.scss
@@ -498,3 +498,7 @@ label {
     }
   }
 }
+
+.page-contact-details {
+  @include skin-typography($style: "article-text", $link-style: "content-body");
+}

--- a/packages/global/scss/core.scss
+++ b/packages/global/scss/core.scss
@@ -498,7 +498,16 @@ label {
     }
   }
 }
-
+.page {
+  &--content-event {
+    .page-dates {
+      &__content-starts,
+      &__content-ends {
+        @include skin-typography($style: "article-text", $link-style: "content-body");
+      }
+    }
+  }
+}
 .page-contact-details {
   @include skin-typography($style: "article-text", $link-style: "content-body");
 }


### PR DESCRIPTION
Added additional event/contact details above the content body to display address info, website & phone/fax details about the display of the image and body copy.  

![events-page](https://user-images.githubusercontent.com/3845869/191067388-41debed4-aede-4ede-b394-0c57d3ddd9c6.jpeg)
