### PR TITLE
Add event submit wufoo suport

### DIFF
--- a/packages/global/components/layouts/website-section/upcoming-feed.marko
+++ b/packages/global/components/layouts/website-section/upcoming-feed.marko
@@ -4,7 +4,7 @@ import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 $ const { id, alias, name, pageNode } = input;
 $ const sections = getAsArray(input, "sections");
 
-$ const { pagination: p } = out.global;
+$ const { pagination: p, site } = out.global;
 $ const withAds = defaultValue(input.withAds, false);
 $ const now = Date.now();
 $ const queryParams = {
@@ -70,11 +70,35 @@ $ const perPage = 12;
     <global-section-feed-wrapper aliases=aliases alias=alias modifiers=["upcoming"] with-ads=withAds>
       <@query-params ...queryParams />
       <@rail>
-        <h3 class="sticky-top">Submit a Conference</h3>
-        <p>Coming soon</p>
+         <marko-web-node-list collapsible=false class="sticky-top" modifiers=["section-list", "submit-event"]>
+          <@header>
+            Submit A Conference
+          </@header>
+          <@body>
+            <marko-web-auth0-access|context| requires-registration=true>
+              <if(!context.canAccess)>
+                <p>
+                  To submit your event please <a href="/login">sign in!</a>
+                </p>
+              </if>
+              <else-if(site.get("wufoo.userName") && site.get("wufoo.submitEvent.formHash"))>
+                <marko-web-browser-component
+                  name="WufooForm"
+                  props={
+                    userName: site.get("wufoo.userName"),
+                    formHash: site.get("wufoo.submitEvent.formHash"),
+                    height: site.get("wufoo.submitEvent.formHeight"),
+                  }
+                />
+              </else-if>
+              <else>
+                <p>Coming soon</p>
+              </else>
+            </marko-web-auth0-access>
+          </@body>
+        </marko-web-node-list>
       </@rail>
       <@rail>
-        <!-- <h3 class="sticky-top">Rail lower</h3> -->
       </@rail>
     </global-section-feed-wrapper>
   </@section>

--- a/packages/global/components/layouts/website-section/upcoming-feed.marko
+++ b/packages/global/components/layouts/website-section/upcoming-feed.marko
@@ -78,7 +78,7 @@ $ const perPage = 12;
             <marko-web-auth0-access|context| requires-registration=true>
               <if(!context.canAccess)>
                 <p>
-                  To submit your event please <a href="/login">sign in!</a>
+                  To submit a conference please <a href="/login">sign in!</a>
                 </p>
               </if>
               <else-if(site.get("wufoo.userName") && site.get("wufoo.submitEvent.formHash"))>

--- a/packages/global/scss/core.scss
+++ b/packages/global/scss/core.scss
@@ -417,6 +417,11 @@ label {
       }
     }
   }
+  &--submit-event {
+    #{ $self }__body {
+      padding: 0;
+    }
+  }
 }
 .top-story {
   &__row {
@@ -497,17 +502,4 @@ label {
       width: 24px;
     }
   }
-}
-.page {
-  &--content-event {
-    .page-dates {
-      &__content-starts,
-      &__content-ends {
-        @include skin-typography($style: "article-text", $link-style: "content-body");
-      }
-    }
-  }
-}
-.page-contact-details {
-  @include skin-typography($style: "article-text", $link-style: "content-body");
 }

--- a/sites/labpulse.com/config/site.js
+++ b/sites/labpulse.com/config/site.js
@@ -52,9 +52,13 @@ module.exports = {
   gtm: {
     containerId: 'GTM-W5TZ4SS',
   },
-  // wufoo: {
-  //   userName: 'randallreilly',
-  // },
+  wufoo: {
+    userName: null,
+    submitEvent: {
+      formHash: null,
+      formHeight: 'auto',
+    },
+  },
   inquiry: {
     enabled: true,
     directSend: false,


### PR DESCRIPTION
We will need to get the userName and specific hash from the group to finish setting this up.  The right rail form is gated and will only show the submit event, wufoo form, once the user is authenticated.  

**Not Logged In:**
<img width="1005" alt="Screen Shot 2022-09-20 at 9 34 58 AM" src="https://user-images.githubusercontent.com/3845869/191288104-6348a3f2-0379-4d83-be6a-b07584fcc29a.png">
**Logged In with sample form(Will have to add wufoo styling once account is setup):**
<img width="1002" alt="Screen Shot 2022-09-20 at 9 34 39 AM" src="https://user-images.githubusercontent.com/3845869/191288152-e84f8967-f856-4398-84f4-3f4978263b1c.png">
**Logged in without wufoo configured:**
<img width="1005" alt="Screen Shot 2022-09-20 at 9 33 32 AM" src="https://user-images.githubusercontent.com/3845869/191288178-65aac45f-e3a7-4342-8dca-9831df5fa2fa.png">
