### PR TITLE
Add config based wufoo form to upcoming section layout

### DIFF
--- a/packages/global/components/layouts/website-section/upcoming-feed.marko
+++ b/packages/global/components/layouts/website-section/upcoming-feed.marko
@@ -3,8 +3,12 @@ import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 
 $ const { id, alias, name, pageNode } = input;
 $ const sections = getAsArray(input, "sections");
+$ const { pagination: p, site } = out.global;
 
-$ const { pagination: p } = out.global;
+$ const wufooUserName = site.get("wufoo.userName");
+$ const wufooFormTitle = site.get(`wufoo.${alias}.title`) || 'Drop us a line!';
+$ const wufooFormHash = site.get(`wufoo.${alias}.hash`);
+
 $ const withAds = defaultValue(input.withAds, false);
 $ const now = Date.now();
 $ const queryParams = {
@@ -70,8 +74,27 @@ $ const perPage = 12;
     <global-section-feed-wrapper aliases=aliases alias=alias modifiers=["upcoming"] with-ads=withAds>
       <@query-params ...queryParams />
       <@rail>
-        <h3 class="sticky-top">Submit a Conference</h3>
-        <p>Coming soon</p>
+        <div class="sticky-top">
+          <if(wufooFormHash && wufooUserName)>
+            $ const props = {
+              userName: wufooUserName,
+              formHash: wufooFormHash,
+            };
+              <marko-web-element block-name=blockName name="wufoo-form">
+                <div class="contact-us-form contact-us-form__header">
+                  ${wufooFormTitle}
+                </div>
+                <marko-web-browser-component
+                  name="WufooForm"
+                  props=props
+                />
+              </marko-web-element>
+          </if>
+          <else>
+            <h3>Submit a Conference</h3>
+            <p>Coming soon ${alias}</p>
+          </else>
+        </div>
       </@rail>
       <@rail>
         <!-- <h3 class="sticky-top">Rail lower</h3> -->

--- a/sites/labpulse.com/config/site.js
+++ b/sites/labpulse.com/config/site.js
@@ -56,9 +56,13 @@ module.exports = {
   gtm: {
     containerId: 'GTM-W5TZ4SS',
   },
-  // wufoo: {
-  //   userName: 'randallreilly',
-  // },
+  wufoo: {
+    userName: 'labpulse',
+    'resources/conferences': {
+      title: 'Submit A Conference!',
+      hash: 'z1op3s8517hgdmv',
+    },
+  },
   inquiry: {
     enabled: true,
     directSend: false,


### PR DESCRIPTION
Add config based support to the upcoming section layout to be able to setup alias based submission forms in the right rail.  

@TODO: port theme css support to labPulses's wufoo account.  

<img width="1069" alt="Screen Shot 2022-09-27 at 2 06 48 PM" src="https://user-images.githubusercontent.com/3845869/192614404-43349bb0-df90-4291-affb-570998f0abde.png">
