### PR TITLE
Add newsletter signup to content page and footer of labpulse

### DIFF
--- a/packages/global/components/blocks/marko.json
+++ b/packages/global/components/blocks/marko.json
@@ -2,6 +2,9 @@
   "taglib-imports": [
     "./load-more/marko.json"
   ],
+  "<global-newsletter-signup-banner-large-block>": {
+    "template": "./newsletter-signup-banner-large.marko"
+  },
   "<global-content-meter-block>": {
     "template": "./content-meter.marko"
   },

--- a/packages/global/components/blocks/newsletter-signup-banner-large.marko
+++ b/packages/global/components/blocks/newsletter-signup-banner-large.marko
@@ -1,0 +1,30 @@
+$ const blockName = "newsletter-signup-banner-large";
+
+$ const { site } = out.global;
+$ const { action, hiddenInputs, name, description } = site.getAsObject('newsletter.signupBannerLarge');
+
+<if(action && description && name)>
+  <marko-web-block name=blockName class=input.class>
+    <marko-web-element block-name=blockName name="name">
+      ${name}
+    </marko-web-element>
+    <marko-web-element block-name=blockName name="description">
+      $!{description}
+    </marko-web-element>
+    <form method="GET" action=action class=`${blockName}__form`>
+      <label for="newsletter-signup-banner-large-email" class="sr-only">Email</label>
+      <input
+        id="newsletter-signup-banner-large-email"
+        class="form-control"
+        placeholder="example@gmail.com"
+        type="email"
+        name="email"
+        required
+      />
+      <for|item| of=hiddenInputs>
+        <input type="hidden" name=item.name value=item.value />
+      </for>
+      <button class="btn btn-primary" type="submit">Sign Up</button>
+    </form>
+  </marko-web-block>
+</if>

--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -3,6 +3,7 @@ import contentIframe from "@science-medicine-group/package-global/utils/content-
 import getContentPreview from "@parameter1/base-cms-marko-web-theme-monorail/utils/get-content-preview";
 
 $ const { site, contentMeterState } = out.global;
+$ const newsletterConfig = site.getAsObject('newsletter.signupBannerLarge');
 $ const { id, type, pageNode, showReadNextBlock, showBottomAdBlock, showTopStoryBlock, ...rest } = input;
 $ const sections = getAsArray(input, "sections");
 
@@ -162,8 +163,10 @@ $ const shouldInjectAds = ["article", "video", "news", "podcast"].includes(type)
                   />
                 </if>
               </else>
-
             </marko-web-identity-x-access>
+            <if(newsletterConfig)>
+              <global-newsletter-signup-banner-large-block class="mb-block" />
+            </if>
           </default-theme-page-contents>
         </div>
       </div>

--- a/packages/global/components/site-footer.marko
+++ b/packages/global/components/site-footer.marko
@@ -60,6 +60,38 @@ $ const tagline = site.get("tagline");
       </if>
 
       <div class="row">
+        $ const newsletterBlock = "site-footer-newsletter";
+        <if(newsletterConfig.enable && newsletterConfig.action)>
+          <div class=`col-md-${newsletterConfig.colspan || 4} mb-block`>
+            <marko-web-block name=newsletterBlock>
+              <marko-web-element block-name=newsletterBlock name="header">
+                $!{newsletterConfig.name}
+              </marko-web-element>
+              <if(newsletterConfig.description)>
+                <marko-web-element block-name=newsletterBlock name="description">
+                  $!{newsletterConfig.description}
+                </marko-web-element>
+              </if>
+              <form action=newsletterConfig.action method="GET">
+                <div class="form-group">
+                  <label for="footer-newsletter-signup-email">Email</label>
+                  <input
+                    id="footer-newsletter-signup-email"
+                    class="form-control"
+                    type="email"
+                    placeholder="example@gmail.com"
+                    name="email"
+                    required
+                  />
+                  <for|item| of=newsletterConfig.hiddenInputs>
+                    <input type="hidden" name=item.name value=item.value />
+                  </for>
+                </div>
+                <button class="btn btn-primary" type="submit">Sign Up</button>
+              </form>
+            </marko-web-block>
+          </div>
+        </if>
         <div class=`col-md-${site.get("navigation.footer.col1.colspan") || 2}`>
           <!-- sections -->
           <theme-site-menu-section

--- a/sites/labpulse.com/config/navigation.js
+++ b/sites/labpulse.com/config/navigation.js
@@ -178,27 +178,45 @@ module.exports = {
   },
   footer: {
     col1: {
-      label: 'Business Insights',
-      items: businessInsights,
+      label: 'Topics',
+      colspan: 5,
+      items: [
+        { href: '/business-insights', label: 'Business Insights' },
+        { href: '/diagnostic-technologies', label: 'Diagnostic Technologies' },
+        { href: '/diseases', label: 'Diseases' },
+        { href: '/point-of-care-testing', label: 'Point-of-Care Testing' },
+        { href: '/research-and-development', label: 'Research & Development' },
+      ],
     },
     col2: {
-      label: 'Research & Development',
-      colspan: '3',
-      items: researchDevelopment,
-    },
-    col3: {
-      label: 'Diagnostic Technologies',
-      colspan: '3',
-      items: diagnosticTechnologies,
-    },
-    col4: {
-      label: 'Diseases',
-      items: diseases,
-    },
-    col5: {
       label: 'Resources',
       items: resources,
     },
+    // Original Footer Navigation
+    // col1: {
+    //   label: 'Business Insights',
+    //   items: businessInsights,
+    // },
+    // col2: {
+    //   label: 'Research & Development',
+    //   colspan: '3',
+    //   items: researchDevelopment,
+    // },
+    // col3: {
+    //   label: 'Diagnostic Technologies',
+    //   colspan: '3',
+    //   items: diagnosticTechnologies,
+    // },
+    // col4: {
+    //   label: 'Diseases',
+    //   items: diseases,
+    // },
+    // col5: {
+    //   label: 'Resources',
+    //   items: resources,
+    // },
+
+
     // col3: {
     //   label: 'More',
     //   items: [

--- a/sites/labpulse.com/config/newsletter.js
+++ b/sites/labpulse.com/config/newsletter.js
@@ -11,6 +11,7 @@ module.exports = {
   },
   signupFooter: {
     ...baseConfig,
+    colspan: 5,
     enable: true,
     name: 'Stay Connected',
     description: 'Breaking clinical, business, and industry news about the clinical labcommunity',

--- a/sites/labpulse.com/config/newsletter.js
+++ b/sites/labpulse.com/config/newsletter.js
@@ -1,71 +1,18 @@
-const privacyPolicy = require('./privacy-policy');
-
 const baseConfig = {
-  action: 'https://sciencemedicinegroup.dragonforms.com/loading.do',
-  hiddenInputs: [
-    { name: 'omedasite', value: 'sab_subscriptions' },
-  ],
-};
-
-const defaults = {
-  name: 'Don’t Miss Out',
-  description: 'Get the business tips, industry insights and trending news every professional needs to know.',
-  defaultNewsletter: {
-    deploymentTypeId: 29,
-    name: 'Daily Report',
-    eventCategory: 'Daily Newsletter Subscription',
-  },
-  privacyPolicy,
-  newsletters: [
-    {
-      deploymentTypeId: 30,
-      name: 'Equipment Weekly',
-      description: 'Roundup of news and reviews',
-      eventCategory: 'Weekly Equipment Subscription',
-    },
-    {
-      deploymentTypeId: 31,
-      name: 'Technology Weekly',
-      description: 'Top tech developments in the industry',
-      eventCategory: 'Weekly Technology Subscription',
-    },
-    {
-      deploymentTypeId: 32,
-      name: 'Weekend Newsletter',
-      description: 'The top news of the week in the industry',
-      eventCategory: 'Weekend Newsletter',
-    },
-  ],
-  demographic: {
-    id: 72,
-    label: 'Your primary role?',
-    values: [
-      { id: 123, label: 'Other' },
-    ],
-  },
+  action: '/user/subscribe',
+  hiddenInputs: [],
 };
 
 module.exports = {
-  // uses inline omeda form
-  signupBanner: {
-    ...defaults,
-    imagePath: 'files/base/smg/all/image/static/newsletter-pushdown/sab-full.png',
-  },
-  pushdown: {
-    ...defaults,
-    imagePath: 'files/base/smg/all/image/static/newsletter-pushdown/sab-half.png',
-    description: 'Description',
-  },
-
-  // links off to seperate omeda dragonform
   signupBannerLarge: {
     ...baseConfig,
     name: 'Don’t Miss Out',
-    description: 'Description',
+    description: 'Breaking clinical, business, and industry news about the clinical labcommunity',
   },
   signupFooter: {
     ...baseConfig,
-    name: 'Newsletter for Professionals',
-    description: 'Description',
+    enable: true,
+    name: 'Stay Connected',
+    description: 'Breaking clinical, business, and industry news about the clinical labcommunity',
   },
 };


### PR DESCRIPTION
I have it currently setup to display at the bottom of the default content layout & with in the footer.  This does push two columns of the footer navigation under this signup box, but this can be disable by removing enable: true from the newsletter.signupFooter config.  

**We will also need update verbiage from the group.**


<img width="1091" alt="Screen Shot 2022-09-27 at 5 00 42 PM" src="https://user-images.githubusercontent.com/3845869/192644750-080d5ac7-5829-43e2-82f9-2f96f76e287d.png">
