### PR TITLE
Add contact us page override with contact us form

### DIFF
--- a/packages/global/templates/dynamic-page/contact-us.marko
+++ b/packages/global/templates/dynamic-page/contact-us.marko
@@ -1,0 +1,56 @@
+$ const { id, type, pageNode } = input;
+
+$ const { site } = out.global;
+
+$ const wufooUserName = site.get("wufoo.userName");
+$ const wufooFormTitle = site.get("wufoo.contact-us.title") || 'Drop us a line!';
+$ const wufooFormHash = site.get("wufoo.contact-us.hash");
+
+<global-content-wrapper-layout
+  id=id
+  type=type
+  page-node=pageNode
+>
+
+  <@section|{ blockName, content }|>
+    $ const { primarySection } = content;
+    <div class="section-page-header">
+      <theme-content-page-breadcrumbs section=primarySection />
+      <marko-web-content-name tag="h1" block-name=blockName obj=content />
+    </div>
+  </@section>
+
+  <@section|{ blockName, content }|>
+    $ const { primarySection } = content;
+    <div class="row">
+      <div class="col-lg-8">
+        <div class="content-page-body">
+          <default-theme-page-contents|{ blockName }| attrs={ "data-gallery-id": id }>
+            $ const bodyId = `content-body-${content.id}`;
+            <marko-web-content-body block-name=blockName obj=content attrs={ id: bodyId } />
+          </default-theme-page-contents>
+        </div>
+      </div>
+      <div class="col-lg-4">
+        <if(wufooFormHash && wufooUserName)>
+          $ const props = {
+            userName: wufooUserName,
+            formHash: wufooFormHash,
+          };
+          <marko-web-node-list class="wufoo-form" block-name="node-list" modifiers=["wufoo"] collapsible=false>
+            <@header>
+              ${wufooFormTitle}
+            </@header>
+            <@body>
+              <marko-web-browser-component
+                name="WufooForm"
+                props=props
+              />
+            </@body>
+          </marko-web-node-list>
+        </if>
+      </div>
+    </div>
+  </@section>
+
+</global-content-wrapper-layout>

--- a/sites/labpulse.com/config/site.js
+++ b/sites/labpulse.com/config/site.js
@@ -61,7 +61,7 @@ module.exports = {
   wufoo: {
     userName: 'labpulse',
     'contact-us': {
-      title: 'Submit your request!',
+      title: 'Drop us a line!',
       hash: 'mbaniw419houf4',
     },
     'resources/conferences': {

--- a/sites/labpulse.com/config/site.js
+++ b/sites/labpulse.com/config/site.js
@@ -60,6 +60,10 @@ module.exports = {
   },
   wufoo: {
     userName: 'labpulse',
+    'contact-us': {
+      title: 'Submit your request!',
+      hash: 'mbaniw419houf4',
+    },
     'resources/conferences': {
       title: 'Submit A Conference!',
       hash: 'z1op3s8517hgdmv',

--- a/sites/labpulse.com/server/routes/dynamic-page.js
+++ b/sites/labpulse.com/server/routes/dynamic-page.js
@@ -1,8 +1,13 @@
 const { withDynamicPage } = require('@parameter1/base-cms-marko-web/middleware');
 const queryFragment = require('@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/dynamic-page');
 const page = require('@science-medicine-group/package-global/templates/dynamic-page');
+const contactUs = require('@science-medicine-group/package-global/templates/dynamic-page/contact-us');
 
 module.exports = (app) => {
+  app.get('/page/:alias(contact-us)', withDynamicPage({
+    template: contactUs,
+    queryFragment,
+  }));
   app.get('/page/:alias(*)', withDynamicPage({
     template: page,
     queryFragment,


### PR DESCRIPTION
 - Add wufoo form config for contact us
 - Add dynamic page template override for /page/contact-us route
 
 

<img width="1160" alt="Screen Shot 2022-09-28 at 4 07 55 PM" src="https://user-images.githubusercontent.com/3845869/192889059-d811d3d5-6420-4f0c-b87b-7603c870b03c.png">
