### PR TITLE
Add newsletter pushdown & newsletterState middleware for auto expansion

### DIFF
--- a/packages/global/browser/index.js
+++ b/packages/global/browser/index.js
@@ -2,10 +2,12 @@
 import MonoRail from '@parameter1/base-cms-marko-web-theme-monorail/browser';
 import FormLogin from './form-login.vue';
 
+const GlobalSiteNewsletterMenu = () => import(/* webpackChunkName: "global-site-newsletter-menu" */ './site-newsletter-menu.vue');
 const ContentMeterTrack = () => import(/* webpackChunkName: "content-meter-tracker" */ './track-content-meter.vue');
 const PreferenceCenter = () => import(/* webpackChunkName: "braze-preference-center" */ './braze-preference-center.vue');
 
 export default (Browser) => {
+  const { EventBus } = Browser;
   MonoRail(Browser, {
     enableOmedaIdentityX: false,
     idxArgs: {
@@ -13,5 +15,8 @@ export default (Browser) => {
     },
   });
   Browser.register('ContentMeterTrack', ContentMeterTrack);
+  Browser.register('GlobalSiteNewsletterMenu', GlobalSiteNewsletterMenu, {
+    provide: { EventBus },
+  });
   Browser.register('PreferenceCenter', PreferenceCenter);
 };

--- a/packages/global/browser/site-newsletter-menu.vue
+++ b/packages/global/browser/site-newsletter-menu.vue
@@ -8,6 +8,7 @@
         :disabled="disabled"
         :image-src="imageSrc"
         :image-srcset="imageSrcset"
+        :privacy-policy-link="privacyPolicyLink"
         @focus="$emit('focus', { step: 1 })"
         @error="$emit('error', { step: 1, error: $event })"
       />
@@ -48,6 +49,10 @@ export default {
     imageSrcset: {
       type: String,
       default: null,
+    },
+    privacyPolicyLink: {
+      type: Object,
+      required: true,
     },
     initiallyExpanded: {
       type: Boolean,

--- a/packages/global/browser/site-newsletter-menu.vue
+++ b/packages/global/browser/site-newsletter-menu.vue
@@ -1,0 +1,94 @@
+<template>
+  <aside :class="classNames">
+    <div :class="element('container')">
+      <signup
+        :block-name="blockName"
+        :name="name"
+        :description="description"
+        :disabled="disabled"
+        :image-src="imageSrc"
+        :image-srcset="imageSrcset"
+        @focus="$emit('focus', { step: 1 })"
+        @error="$emit('error', { step: 1, error: $event })"
+      />
+    </div>
+  </aside>
+</template>
+
+<script>
+import Signup from './site-newsletter-menu/signup.vue';
+
+export default {
+  inject: ['EventBus'],
+  components: {
+    Signup,
+  },
+
+  props: {
+    siteName: {
+      type: String,
+      required: true,
+    },
+    name: {
+      type: String,
+      required: true,
+    },
+    description: {
+      type: String,
+      required: true,
+    },
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+    imageSrc: {
+      type: String,
+      default: null,
+    },
+    imageSrcset: {
+      type: String,
+      default: null,
+    },
+    initiallyExpanded: {
+      type: Boolean,
+      default: false,
+    },
+  },
+
+  data: () => ({
+    blockName: 'site-newsletter-menu',
+    didLoad: false,
+    email: null,
+    expanded: undefined,
+    step: 1,
+  }),
+
+  computed: {
+    currentlyExpanded() {
+      if (this.expanded != null) return this.expanded;
+      return this.initiallyExpanded;
+    },
+
+    classNames() {
+      const { blockName } = this;
+      const classes = [blockName];
+      if (this.currentlyExpanded) classes.push(`${blockName}--open`);
+      return classes;
+    },
+  },
+
+  mounted() {
+    if (this.initiallyExpanded) this.didLoad = true;
+    this.EventBus.$on('newsletter-menu-expanded', (expanded) => {
+      this.expanded = expanded;
+      if (expanded) this.didLoad = true;
+    });
+  },
+
+  methods: {
+    element(elementName) {
+      return `${this.blockName}__${elementName}`;
+    },
+  },
+};
+</script>

--- a/packages/global/browser/site-newsletter-menu/signup.vue
+++ b/packages/global/browser/site-newsletter-menu/signup.vue
@@ -21,7 +21,7 @@
         <input
           id="newsletter-menu-email"
           v-model="email"
-          class="form-control mb-block"
+          class="form-control"
           :disabled="isLoading"
           placeholder="example@gmail.com"
           type="email"
@@ -29,6 +29,12 @@
           required
           @focus="didFocus = true"
         >
+        <div :class="`${blockName}__privacy-policy`">
+          By submitting your email, you agree to our
+          <a :href="privacyPolicyLink.href" :target="privacyPolicyLink.target" rel="noopener">
+            {{ privacyPolicyLink.label }}
+          </a>. You can opt out at any time.
+        </div>
         <sign-up-button
           :class="element('form-button')"
           :is-loading="isLoading"
@@ -80,6 +86,10 @@ export default {
     imageSrcset: {
       type: String,
       default: null,
+    },
+    privacyPolicyLink: {
+      type: Object,
+      required: true,
     },
   },
 

--- a/packages/global/browser/site-newsletter-menu/signup.vue
+++ b/packages/global/browser/site-newsletter-menu/signup.vue
@@ -21,7 +21,7 @@
         <input
           id="newsletter-menu-email"
           v-model="email"
-          class="form-control"
+          class="form-control mb-block"
           :disabled="isLoading"
           placeholder="example@gmail.com"
           type="email"

--- a/packages/global/browser/site-newsletter-menu/signup.vue
+++ b/packages/global/browser/site-newsletter-menu/signup.vue
@@ -1,0 +1,119 @@
+<template>
+  <div class="row">
+    <div :class="element('image-wrapper', ['d-none', 'd-md-flex', 'col-md-5', 'col-lg-4'])">
+      <img
+        v-if="imageSrc"
+        :src="imageSrc"
+        :srcset="imageSrcset"
+        :alt="name"
+        :class="element('image')"
+      >
+    </div>
+    <div :class="element('form-wrapper', ['col-12', 'col-md-6', 'col-lg-5'])">
+      <div :class="element('name')">
+        {{ name }}
+      </div>
+      <!-- eslint-disable-next-line vue/no-v-html -->
+      <div :class="element('description')" v-html="description" />
+
+      <form :class="element('form')" @submit.prevent="submit">
+        <label for="newsletter-menu-email" class="sr-only">Email</label>
+        <input
+          id="newsletter-menu-email"
+          v-model="email"
+          class="form-control"
+          :disabled="isLoading"
+          placeholder="example@gmail.com"
+          type="email"
+          name="email"
+          required
+          @focus="didFocus = true"
+        >
+        <sign-up-button
+          :class="element('form-button')"
+          :is-loading="isLoading"
+          :disabled="disabled"
+        />
+      </form>
+    </div>
+    <div :class="element('close-container', ['d-none', 'd-md-flex', 'col-md-1', 'col-lg-3'])">
+      <close-button
+        :class-name="element('close').join(' ')"
+        target-button=".site-navbar__newsletter-toggler"
+        :icon-modifiers="['lg']"
+      />
+    </div>
+  </div>
+</template>
+
+<script>
+
+import CloseButton from '@parameter1/base-cms-marko-web-theme-monorail/browser/newsletter-close-button.vue';
+import SignUpButton from '@parameter1/base-cms-marko-web-theme-monorail/browser/newsletter-signup-form/sign-up-button.vue';
+
+export default {
+  components: {
+    CloseButton,
+    SignUpButton,
+  },
+  props: {
+    blockName: {
+      type: String,
+      required: true,
+    },
+    name: {
+      type: String,
+      required: true,
+    },
+    description: {
+      type: String,
+      required: true,
+    },
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+    imageSrc: {
+      type: String,
+      default: null,
+    },
+    imageSrcset: {
+      type: String,
+      default: null,
+    },
+  },
+
+  data: () => ({
+    didFocus: false,
+    email: null,
+    error: null,
+    isLoading: false,
+    recaptcha: { loading: false, error: null },
+  }),
+
+  watch: {
+    didFocus(value) {
+      if (value) this.$emit('focus');
+    },
+  },
+
+  methods: {
+    element(elementName, classNames = []) {
+      return [`${this.blockName}__${elementName}`, ...classNames];
+    },
+
+    async submit() {
+      try {
+        this.error = null;
+        this.isLoading = true;
+        window.location.href = `/user/subscribe?email=${this.email}`;
+      } catch (e) {
+        this.error = e;
+        this.$emit('error', e);
+      } finally {
+        this.isLoading = false;
+      }
+    },
+  },
+};
+</script>

--- a/packages/global/browser/ssr.js
+++ b/packages/global/browser/ssr.js
@@ -1,3 +1,7 @@
 import ThemeComponents from '@parameter1/base-cms-marko-web-theme-monorail/browser/ssr';
+import GlobalSiteNewsletterMenu from './site-newsletter-menu.vue';
 
-export default ThemeComponents;
+export default {
+  ...ThemeComponents,
+  GlobalSiteNewsletterMenu,
+};

--- a/packages/global/components/marko.json
+++ b/packages/global/components/marko.json
@@ -29,6 +29,9 @@
   "<global-site-header-c>": {
     "template": "./site-header-c.marko"
   },
+  "<global-site-newsletter-menu>": {
+    "template": "./site-newsletter-menu.marko"
+  },
   "<global-site-menu>": {
     "template": "./site-menu/index.marko"
   },

--- a/packages/global/components/site-header-c.marko
+++ b/packages/global/components/site-header-c.marko
@@ -79,6 +79,7 @@ $ const navigation = {
         icon-modifiers=["lg"]
         icon-name="three-bars"
       />
+      <marko-web-browser-component name="ThemeNewsletterToggleButton" ssr=true />
     </div>
   </default-theme-site-navbar>
 
@@ -92,3 +93,4 @@ $ const navigation = {
   </default-theme-site-navbar>
   <${input.belowNav} />
 </marko-web-block>
+<global-site-newsletter-menu />

--- a/packages/global/components/site-newsletter-menu.marko
+++ b/packages/global/components/site-newsletter-menu.marko
@@ -1,0 +1,32 @@
+import { buildImgixUrl } from "@parameter1/base-cms-image";
+import { getAsObject } from "@parameter1/base-cms-object-path";
+
+$ const { site, config } = out.global;
+$ const {
+  name,
+  description,
+  imagePath,
+  disabled,
+} = site.getAsObject("newsletter.pushdown");
+
+$ const lang = site.config.lang || "en";
+$ const { initiallyExpanded } = getAsObject(out.global, "newsletterState");
+$ const imageSrc = imagePath ? buildImgixUrl(`https://${config.website("imageHost")}/${imagePath}`, { w: 280, auto: "format,compress" }) : null;
+$ const imageSrcset = imageSrc ? `${imageSrc}&dpr=2 2x` : null;
+
+<if(name && description)>
+  <marko-web-browser-component
+    name="GlobalSiteNewsletterMenu"
+    ssr=true
+    props={
+      siteName: config.website("name"),
+      name,
+      description,
+      disabled,
+      imageSrc,
+      imageSrcset,
+      initiallyExpanded,
+      lang
+    }
+  />
+</if>

--- a/packages/global/components/site-newsletter-menu.marko
+++ b/packages/global/components/site-newsletter-menu.marko
@@ -7,6 +7,7 @@ $ const {
   description,
   imagePath,
   disabled,
+  privacyPolicy
 } = site.getAsObject("newsletter.pushdown");
 
 $ const lang = site.config.lang || "en";
@@ -26,6 +27,7 @@ $ const imageSrcset = imageSrc ? `${imageSrc}&dpr=2 2x` : null;
       imageSrc,
       imageSrcset,
       initiallyExpanded,
+      privacyPolicyLink: privacyPolicy,
       lang
     }
   />

--- a/packages/global/middleware/newsletter-state.js
+++ b/packages/global/middleware/newsletter-state.js
@@ -8,7 +8,6 @@ const newsletterState = ({ setCookie = true } = {}) => (req, res, next) => {
   const disabled = get(req, 'query.newsletterDisabled');
   const fromEmail = utmMedium === 'email' || olyEncId || false;
   const canBeInitiallyExpanded = !(hasCookie || fromEmail || disabled);
-  console.log(setCookie);
   const initiallyExpanded = (setCookie === true) && canBeInitiallyExpanded;
 
   // Expire in 14 days (2yr if already signed up)

--- a/packages/global/middleware/newsletter-state.js
+++ b/packages/global/middleware/newsletter-state.js
@@ -1,0 +1,56 @@
+const { get } = require('@parameter1/base-cms-object-path');
+
+const cookieName = 'enlPrompted';
+const newsletterState = ({ setCookie = true } = {}) => (req, res, next) => {
+  const hasCookie = Boolean(get(req, `cookies.${cookieName}`));
+  const utmMedium = get(req, 'query.utm_medium');
+  const olyEncId = get(req, 'query.oly_enc_id');
+  const disabled = get(req, 'query.newsletterDisabled');
+  const fromEmail = utmMedium === 'email' || olyEncId || false;
+  const canBeInitiallyExpanded = !(hasCookie || fromEmail || disabled);
+  console.log(setCookie);
+  const initiallyExpanded = (setCookie === true) && canBeInitiallyExpanded;
+
+  // Expire in 14 days (2yr if already signed up)
+  const days = fromEmail ? 365 * 2 : 14;
+  const maxAge = days * 24 * 60 * 60 * 1000;
+
+  if (initiallyExpanded) {
+    res.cookie(cookieName, true, { maxAge });
+  }
+
+  res.locals.newsletterState = {
+    hasCookie,
+    fromEmail,
+    disabled,
+    initiallyExpanded,
+    // set this for other middlewares to know it can be set later
+    // if formatContentResponse conditions are met
+    canBeInitiallyExpanded,
+    cookie: { name: cookieName, maxAge },
+  };
+  next();
+};
+
+const formatContentResponse = ({ res, content }) => {
+  if (!res.locals.newsletterState) return;
+  const {
+    initiallyExpanded,
+    hasCookie,
+    fromEmail,
+    disabled,
+    cookie,
+  } = res.locals.newsletterState;
+
+  if (get(content, 'userRegistration.isCurrentlyRequired') === true) {
+    res.locals.newsletterState.initiallyExpanded = false;
+  } else if (!initiallyExpanded && !hasCookie && !disabled && !fromEmail) {
+    res.cookie(cookie.name, true, { maxAge: cookie.maxAge });
+    res.locals.newsletterState.initiallyExpanded = true;
+  }
+};
+
+module.exports = {
+  newsletterState,
+  formatContentResponse,
+};

--- a/packages/global/scss/components/_newsletter-pushdown.scss
+++ b/packages/global/scss/components/_newsletter-pushdown.scss
@@ -1,5 +1,5 @@
 .site-newsletter-menu {
-  background: $gray-400;
+  background: $gray-300;
   position: fixed;
   left: 0;
   right: 0;

--- a/packages/global/scss/components/_newsletter-pushdown.scss
+++ b/packages/global/scss/components/_newsletter-pushdown.scss
@@ -1,4 +1,5 @@
 .site-newsletter-menu {
+  background: $gray-400;
   position: fixed;
   left: 0;
   right: 0;

--- a/packages/global/scss/components/_newsletter-pushdown.scss
+++ b/packages/global/scss/components/_newsletter-pushdown.scss
@@ -1,0 +1,13 @@
+.site-newsletter-menu {
+  position: fixed;
+  left: 0;
+  right: 0;
+  top: -1000;
+  transition: top 1s linear;
+  z-index: 1501;
+  border-bottom: 1px solid #c4c6cb;
+  box-shadow: -0px 0px 5px 0px rgba(0,0,0,0.75);
+  &--open {
+    top: 0;
+  }
+}

--- a/packages/global/scss/components/_site-navbar-c.scss
+++ b/packages/global/scss/components/_site-navbar-c.scss
@@ -51,7 +51,8 @@
             padding-right: 0;
           }
           .btn,
-          #{ $self }__toggler {
+          #{ $self }__toggler,
+          #{ $self }__newsletter-toggler {
             width: 40px;
             height: 40px;
             padding: 0;
@@ -59,6 +60,14 @@
             font-size: 1rem;
             background-color: $gray-100;
             border-radius: 4px;
+          }
+          #{ $self }__newsletter-toggler,
+          #{ $self }__newsletter-toggler:focus {
+            border-color: #0000;
+            outline-color: #0000;
+          }
+          #{ $self }__newsletter-toggler:focus svg{
+            fill: $primary
           }
           .btn-subscribe {
             font-size: 12px;

--- a/packages/global/scss/components/_site-navbar-c.scss
+++ b/packages/global/scss/components/_site-navbar-c.scss
@@ -66,9 +66,6 @@
             border-color: #0000;
             outline-color: #0000;
           }
-          #{ $self }__newsletter-toggler:focus svg{
-            fill: $primary
-          }
           .btn-subscribe {
             font-size: 12px;
             @media (min-width: map-get($theme-site-header-breakpoints, small-logo)) {

--- a/packages/global/scss/core.scss
+++ b/packages/global/scss/core.scss
@@ -18,6 +18,7 @@
 @import "./components/section-feed-upcoming";
 @import "./components/content-meter";
 @import "./components/directory-section-feed";
+@import "./components/newsletter-pushdown";
 @import "./components/site-footer";
 @import "./components/site-navbar";
 @import "./components/site-navbar-c";

--- a/sites/labpulse.com/config/newsletter.js
+++ b/sites/labpulse.com/config/newsletter.js
@@ -8,7 +8,7 @@ const defaults = {
 module.exports = {
   pushdown: {
     ...defaults,
-    // imagePath: 'files/base/randallreilly/all/image/static/newsletter-pushdown/ovd-half.png',
+    imagePath: 'files/base/smg/all/image/static/lab/newsletter-phone-half.png',
   },
   signupBannerLarge: {
     ...defaults,

--- a/sites/labpulse.com/config/newsletter.js
+++ b/sites/labpulse.com/config/newsletter.js
@@ -1,19 +1,22 @@
-const baseConfig = {
+const defaults = {
+  name: 'Don’t Miss Out',
+  description: 'Breaking, business, and industry news about the clinical lab community.',
   action: '/user/subscribe',
   hiddenInputs: [],
 };
 
 module.exports = {
+  pushdown: {
+    ...defaults,
+    // imagePath: 'files/base/randallreilly/all/image/static/newsletter-pushdown/ovd-half.png',
+  },
   signupBannerLarge: {
-    ...baseConfig,
-    name: 'Don’t Miss Out',
-    description: 'Breaking, business, and industry news about the clinical lab community.',
+    ...defaults,
   },
   signupFooter: {
-    ...baseConfig,
+    ...defaults,
     colspan: 5,
     enable: true,
     name: 'Stay Connected',
-    description: 'Breaking, business, and industry news about the clinical lab community.',
   },
 };

--- a/sites/labpulse.com/config/newsletter.js
+++ b/sites/labpulse.com/config/newsletter.js
@@ -2,6 +2,11 @@ const defaults = {
   name: 'Don’t Miss Out',
   description: 'Breaking, business, and industry news about the clinical lab community.',
   action: '/user/subscribe',
+  privacyPolicy: {
+    label: 'Privacy Policy',
+    href: '/page/privacy-policy',
+    target: '_blank',
+  },
   hiddenInputs: [],
 };
 

--- a/sites/labpulse.com/server/routes/content.js
+++ b/sites/labpulse.com/server/routes/content.js
@@ -1,4 +1,5 @@
 const withContent = require('@science-medicine-group/package-global/middleware/with-content');
+const { newsletterState, formatContentResponse } = require('@science-medicine-group/package-global/middleware/newsletter-state');
 const queryFragment = require('@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/content-page');
 const contact = require('@science-medicine-group/package-global/templates/content/contact');
 const company = require('../templates/content/company');
@@ -7,28 +8,33 @@ const whitepaper = require('../templates/content/whitepaper');
 const content = require('../templates/content');
 
 module.exports = (app) => {
-  app.get('/*?contact/:id(\\d{8})*', withContent({
+  app.get('/*?contact/:id(\\d{8})*', newsletterState({ setCookie: false }), newsletterState({ setCookie: false }), withContent({
     template: contact,
     queryFragment,
+    formatResponse: formatContentResponse,
   }));
 
-  app.get('/*?company/:id(\\d{8})*', withContent({
+  app.get('/*?company/:id(\\d{8})*', newsletterState({ setCookie: false }), withContent({
     template: company,
     queryFragment,
+    formatResponse: formatContentResponse,
   }));
 
-  app.get('/*?product/:id(\\d{8})*', withContent({
+  app.get('/*?product/:id(\\d{8})*', newsletterState({ setCookie: false }), withContent({
     template: product,
     queryFragment,
+    formatResponse: formatContentResponse,
   }));
 
-  app.get('/*?whitepaper/:id(\\d{8})*', withContent({
+  app.get('/*?whitepaper/:id(\\d{8})*', newsletterState({ setCookie: false }), withContent({
     template: whitepaper,
     queryFragment,
+    formatResponse: formatContentResponse,
   }));
 
-  app.get('/*?/:id(\\d{8})/*|/:id(\\d{8})(/|$)', withContent({
+  app.get('/*?/:id(\\d{8})/*|/:id(\\d{8})(/|$)', newsletterState({ setCookie: false }), withContent({
     template: content,
     queryFragment,
+    formatResponse: formatContentResponse,
   }));
 };

--- a/sites/labpulse.com/server/routes/website-section.js
+++ b/sites/labpulse.com/server/routes/website-section.js
@@ -1,14 +1,16 @@
 const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
+const { newsletterState } = require('@science-medicine-group/package-global/middleware/newsletter-state');
+
 const queryFragment = require('@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/website-section-page');
 const upcoming = require('@science-medicine-group/package-global/templates/website-section/upcoming');
 const section = require('../templates/website-section');
 
 module.exports = (app) => {
-  app.get('/:alias(resources/conferences)', withWebsiteSection({
+  app.get('/:alias(resources/conferences)', newsletterState(), withWebsiteSection({
     template: upcoming,
     queryFragment,
   }));
-  app.get('/:alias([a-z0-9-/]+)', withWebsiteSection({
+  app.get('/:alias([a-z0-9-/]+)', newsletterState(), withWebsiteSection({
     template: section,
     queryFragment,
   }));


### PR DESCRIPTION
Some additional css was added to also fix this menu in place.  Only because the header is sticky now and when the menu expands it has to know to stay with the header.  The page body will scroll behind it.  



<img width="429" alt="Screen Shot 2022-09-29 at 3 48 19 PM" src="https://user-images.githubusercontent.com/3845869/193139261-cd64ddc0-27e7-4996-81d8-64c9b3e00b50.png">
<img width="1790" alt="Screen Shot 2022-09-29 at 3 48 33 PM" src="https://user-images.githubusercontent.com/3845869/193139265-68a856ad-0901-481e-9756-01cebe8b0387.png">
