### PR TITLE
IdentityX+Braze: Preference center update

### DIFF
--- a/packages/braze/browser/subscription-group.vue
+++ b/packages/braze/browser/subscription-group.vue
@@ -10,11 +10,9 @@
         class="custom-control-input"
       >
       <label class="custom-control-label" :for="`custom-boolean-${id}`" :required="required">
-        <strong v-html="label" />
-        <strong v-if="required" class="text-danger">*</strong>
         <span
           v-if="description"
-          class="font-weight-normal d-block text-muted"
+          class="font-weight-normal d-block"
           v-html="description"
         />
       </label>

--- a/packages/braze/graphql/fragments/active-user.js
+++ b/packages/braze/graphql/fragments/active-user.js
@@ -1,0 +1,9 @@
+const gql = require('graphql-tag');
+
+module.exports = gql`
+fragment BrazeActiveUserFragment on AppUser {
+  id
+  email
+  receiveEmail
+}
+`;

--- a/packages/braze/graphql/fragments/custom-boolean.js
+++ b/packages/braze/graphql/fragments/custom-boolean.js
@@ -1,4 +1,5 @@
 const gql = require('graphql-tag');
+const customFieldFragment = require('./custom-field');
 
 module.exports = gql`
 fragment CustomBooleanFieldAnswerFragment on AppUserCustomBooleanFieldAnswer {
@@ -6,18 +7,8 @@ fragment CustomBooleanFieldAnswerFragment on AppUserCustomBooleanFieldAnswer {
   hasAnswered
   value
   field {
-    label
-    externalId {
-      id
-      namespace {
-        provider
-        tenant
-        type
-      }
-      identifier {
-        value
-      }
-    }
+    ...CustomFieldFragment
   }
 }
+${customFieldFragment}
 `;

--- a/packages/braze/graphql/fragments/custom-boolean.js
+++ b/packages/braze/graphql/fragments/custom-boolean.js
@@ -1,0 +1,23 @@
+const gql = require('graphql-tag');
+
+module.exports = gql`
+fragment CustomBooleanFieldAnswerFragment on AppUserCustomBooleanFieldAnswer {
+  id
+  hasAnswered
+  value
+  field {
+    label
+    externalId {
+      id
+      namespace {
+        provider
+        tenant
+        type
+      }
+      identifier {
+        value
+      }
+    }
+  }
+}
+`;

--- a/packages/braze/graphql/fragments/custom-field.js
+++ b/packages/braze/graphql/fragments/custom-field.js
@@ -1,0 +1,20 @@
+const gql = require('graphql-tag');
+
+module.exports = gql`
+fragment CustomFieldFragment on FieldInterface {
+  id
+  active
+  label
+  externalId {
+    id
+    namespace {
+      provider
+      tenant
+      type
+    }
+    identifier {
+      value
+    }
+  }
+}
+`;

--- a/packages/braze/graphql/queries/idx-app-custom-questions.js
+++ b/packages/braze/graphql/queries/idx-app-custom-questions.js
@@ -1,0 +1,15 @@
+const gql = require('graphql-tag');
+const customFieldFragment = require('../fragments/custom-field');
+
+module.exports = gql`
+query BrazeFindAppFields {
+  fields(input: { sort: { field: createdAt, order: asc } }) {
+    edges {
+      node {
+        ...CustomFieldFragment
+      }
+    }
+  }
+}
+${customFieldFragment}
+`;

--- a/packages/braze/graphql/queries/idx-app-user.js
+++ b/packages/braze/graphql/queries/idx-app-user.js
@@ -1,0 +1,16 @@
+const gql = require('graphql-tag');
+const activeUserFragment = require('../fragments/active-user');
+const customBooleanFragment = require('../fragments/custom-boolean');
+
+module.exports = gql`
+query BrazeFindAppUser($input: AppUserQueryInput!) {
+  appUser(input: $input) {
+    ...BrazeActiveUserFragment
+    customBooleanFieldAnswers(input: { onlyActive: true }) {
+      ...CustomBooleanFieldAnswerFragment
+    }
+  }
+}
+${activeUserFragment}
+${customBooleanFragment}
+`;

--- a/packages/braze/hooks/on-user-profile-update.js
+++ b/packages/braze/hooks/on-user-profile-update.js
@@ -1,10 +1,5 @@
-const { get, getAsArray, getAsObject } = require('@parameter1/base-cms-object-path');
-
-const getFormatter = v => (typeof v === 'function' ? v : x => x.payload);
-const filterByExternalId = (arr, type, tenant) => arr.filter((v) => {
-  const ns = getAsObject(v, 'field.externalId.namespace');
-  return ns.provider === 'braze' && ns.type === type && ns.tenant === tenant;
-});
+const { get, getAsArray } = require('@parameter1/base-cms-object-path');
+const { filterByExternalId, getFormatter } = require('../utils');
 
 /**
  *

--- a/packages/braze/routes/preference-center.js
+++ b/packages/braze/routes/preference-center.js
@@ -1,9 +1,12 @@
+const { get, getAsArray } = require('@parameter1/base-cms-object-path');
 const { asyncRoute } = require('@parameter1/base-cms-utils');
 const { validateToken } = require('@parameter1/base-cms-marko-web-recaptcha');
 const { json } = require('express');
 const { RECAPTCHA_V3_SECRET_KEY } = require('../env');
 const template = require('../templates/preference-center');
 const updateAppUser = require('../graphql/mutations/idx-user-update-receive-email');
+const idxAppUser = require('../graphql/queries/idx-app-user');
+const { filterByExternalId } = require('../utils');
 
 const { log } = console;
 const buildAnswers = (questions, optIns) => {
@@ -16,6 +19,60 @@ const buildAnswers = (questions, optIns) => {
     if (!fieldId) return arr;
     return [...arr, { fieldId, value }];
   }, []);
+};
+const buildOptins = async ({
+  email,
+  identityX,
+  braze,
+  questions,
+}) => {
+  // @todo load questions from IdX context
+  const optIns = questions.reduce((obj, sg) => ({ ...obj, [sg.groupId]: false }), {});
+  log(`Finding opt-ins for ${email}`);
+
+  try {
+    // Load user+answers, if present
+    const { data } = await identityX.client.query({
+      query: idxAppUser,
+      variables: {
+        input: { email },
+      },
+    });
+    const answers = filterByExternalId(getAsArray(data, 'appUser.customBooleanFieldAnswers'), 'subscriptionGroup', braze.tenant);
+
+    if (answers.length) {
+      answers.forEach((ans) => {
+        const key = get(ans, 'field.externalId.identifier.value');
+        if (ans.hasAnswered) optIns[key] = ans.value;
+      });
+      if (answers.every(ans => ans.hasAnswered)) {
+        log('Returning from IdX', optIns);
+        return optIns;
+      }
+    }
+  } catch (e) {
+    // Do nothing if the idx lookup failed
+  }
+
+  // Check Braze
+  try {
+    log('Checking Braze');
+    const { users } = await braze.getSubscriptionStatus(email);
+    if (users) {
+      users.forEach((entry) => {
+        const groups = entry.subscription_groups || [];
+        groups.forEach((group) => {
+          optIns[group.id] = group.status === 'Subscribed';
+        });
+        log('Returning from Braze', optIns);
+        return optIns;
+      });
+    }
+  } catch (e) {
+    // Do nothing if the braze lookup failed
+  }
+  log('Returning set!', optIns);
+  return optIns;
 };
 
 module.exports = (app) => {
@@ -41,27 +98,15 @@ module.exports = (app) => {
   };
 
   app.get('/user/subscribe/check', json(), asyncRoute(async (req, res) => {
-    const { braze } = req;
+    const { braze, identityX } = req;
     const { email } = req.query;
     const questions = app.locals.site.getAsArray('braze.subscriptionGroups');
-    const optIns = questions.reduce((obj, q) => ({ ...obj, [q.groupId]: false }), {});
-
-    if (email) {
-      try {
-        const { users } = await braze.getSubscriptionStatus(email);
-        if (users) {
-          users.forEach((entry) => {
-            const groups = entry.subscription_groups || [];
-            groups.forEach((group) => {
-              optIns[group.id] = group.status === 'Subscribed';
-            });
-          });
-        }
-      } catch (e) {
-        // Warn but do nothing if the user lookup failed
-        log('Unable to look up braze user state', email, e);
-      }
-    }
+    const optIns = await buildOptins({
+      questions,
+      email,
+      braze,
+      identityX,
+    });
     res.json(optIns);
   }));
 

--- a/packages/braze/routes/preference-center.js
+++ b/packages/braze/routes/preference-center.js
@@ -11,10 +11,11 @@ const buildAnswers = (questions, optIns) => {
     map.set(q.groupId, q.id);
     return map;
   }, new Map());
-  return Object.entries(optIns).map(([brazeId, value]) => ({
-    fieldId: questionMap.get(brazeId),
-    value,
-  }));
+  return Object.entries(optIns).reduce((arr, [brazeId, value]) => {
+    const fieldId = questionMap.get(brazeId);
+    if (!fieldId) return arr;
+    return [...arr, { fieldId, value }];
+  }, []);
 };
 
 module.exports = (app) => {

--- a/packages/braze/templates/preference-center.marko
+++ b/packages/braze/templates/preference-center.marko
@@ -5,7 +5,7 @@ $ const type = "profile";
 $ const title = `${siteName} Preference Center`;
 $ const description = `Update your ${siteName} subscriptions`;
 $ const email = req.query && req.query.email || '';
-$ const questions = site.getAsArray('braze.subscriptionGroups');
+$ const { questions } = input;
 $ const { RECAPTCHA_V3_SITE_KEY } = require('../env');
 
 <marko-web-default-page-layout type=type title=title description=description>

--- a/packages/braze/utils.js
+++ b/packages/braze/utils.js
@@ -1,0 +1,9 @@
+const { getAsObject } = require('@parameter1/base-cms-object-path');
+
+module.exports = {
+  filterByExternalId: (arr, type, tenant) => arr.filter((v) => {
+    const ns = getAsObject(v, 'field.externalId.namespace');
+    return ns.provider === 'braze' && ns.type === type && ns.tenant === tenant;
+  }),
+  getFormatter: v => (typeof v === 'function' ? v : x => x.payload),
+};

--- a/packages/global/config/braze.js
+++ b/packages/global/config/braze.js
@@ -4,16 +4,8 @@ const { validate } = require('@parameter1/joi/utils');
 module.exports = (params = {}) => {
   const {
     siteName,
-    subscriptionGroups,
   } = validate(Joi.object({
     siteName: Joi.string().required().description('The Braze site membership identifier.'),
-    // @todo remove this when they can be retrieved from IdX
-    subscriptionGroups: Joi.array().items(Joi.object({
-      id: Joi.string().required().description('The IdentityX field ID'),
-      label: Joi.string().required().description('Line 1/title'),
-      description: Joi.string().description('Line 2/description'),
-      groupId: Joi.string().required().description('The Braze subscription group ID'),
-    })).description('The subscription options for the Braze preference center.'),
   }), params);
 
   return {
@@ -34,6 +26,5 @@ module.exports = (params = {}) => {
       ...payload,
       site_membership: { add: siteName },
     }),
-    subscriptionGroups,
   };
 };

--- a/sites/auntminnie.com/config/braze.js
+++ b/sites/auntminnie.com/config/braze.js
@@ -2,7 +2,4 @@ const config = require('@science-medicine-group/package-global/config/braze');
 
 module.exports = config({
   siteName: 'AM',
-  subscriptionGroups: [
-    // @todo read from IdentityX fields! hardcoding for now.
-  ],
 });

--- a/sites/auntminnieasia.com/config/braze.js
+++ b/sites/auntminnieasia.com/config/braze.js
@@ -2,7 +2,4 @@ const config = require('@science-medicine-group/package-global/config/braze');
 
 module.exports = config({
   siteName: 'AMA',
-  subscriptionGroups: [
-    // @todo read from IdentityX fields! hardcoding for now.
-  ],
 });

--- a/sites/auntminnieeurope.com/config/braze.js
+++ b/sites/auntminnieeurope.com/config/braze.js
@@ -2,7 +2,4 @@ const config = require('@science-medicine-group/package-global/config/braze');
 
 module.exports = config({
   siteName: 'AME',
-  subscriptionGroups: [
-    // @todo read from IdentityX fields! hardcoding for now.
-  ],
 });

--- a/sites/drbicuspid.com/config/braze.js
+++ b/sites/drbicuspid.com/config/braze.js
@@ -2,7 +2,4 @@ const config = require('@science-medicine-group/package-global/config/braze');
 
 module.exports = config({
   siteName: 'DrBicuspid',
-  subscriptionGroups: [
-    // @todo read from IdentityX fields! hardcoding for now.
-  ],
 });

--- a/sites/labpulse.com/config/braze.js
+++ b/sites/labpulse.com/config/braze.js
@@ -2,31 +2,4 @@ const config = require('@science-medicine-group/package-global/config/braze');
 
 module.exports = config({
   siteName: 'LabPulse',
-  subscriptionGroups: [
-    // @todo read from IdentityX fields! hardcoding for now.
-    {
-      id: '632b6e95ae524333855b92eb', // IdentityX boolean question id
-      label: 'Letter from the Editor',
-      description: 'Send me roundups of all the latest clinical and industry news.',
-      groupId: '7cfdb3d3-0fbf-4ed8-a058-9beae72276a3',
-    },
-    {
-      id: '632b6f54ae5243fd6c5b92ec',
-      label: 'Breaking News',
-      description: 'Send me breaking news about research, business, and other developments.',
-      groupId: '423213b2-8d3a-44e8-9bc0-2036fb140cb8',
-    },
-    {
-      id: '632b6f7c6fe1916e1695d29c',
-      label: 'Market Research Panel',
-      description: 'Notify me about ongoing market research activities at LabPulse.com. This confidential service fully complies with our privacy policy.',
-      groupId: '7ae331cb-7736-4bd6-9af9-400c5a1bcee5',
-    },
-    {
-      id: '632b6f96ae524321925b92ed',
-      label: 'Spotlight',
-      description: 'The LabPulse Spotlight can help you make the most of your LabPulse membership. Get notifications about new content, services, or educational resources designed to help you sharpen your skills and grow professionally. Join the Spotlight today!',
-      groupId: '63077630-7fc8-4fa7-bcd8-f1ebaab0a7a9',
-    },
-  ],
 });

--- a/sites/scienceboard.net/config/braze.js
+++ b/sites/scienceboard.net/config/braze.js
@@ -2,7 +2,4 @@ const config = require('@science-medicine-group/package-global/config/braze');
 
 module.exports = config({
   siteName: 'SAB',
-  subscriptionGroups: [
-    // @todo read from IdentityX fields! hardcoding for now.
-  ],
 });


### PR DESCRIPTION
- Fixes error with Braze questionMap
- Now reads questions from IdentityX (using the `fields()` query), replacing hard-coded static values.
- Now reads submitted preferences preferentially from IdentityX.