### PR TITLE
Set default country code from MaxMind

### DIFF
--- a/packages/global/package.json
+++ b/packages/global/package.json
@@ -38,6 +38,7 @@
     "@parameter1/omeda-graphql-client-express": "^0.4.2",
     "@science-medicine-group/package-auth0": "^0.0.0",
     "@science-medicine-group/package-braze": "^1.6.1",
+    "@science-medicine-group/package-maxmind-geoip": "^0.0.0",
     "@science-medicine-group/package-zero-bounce": "^0.0.0",
     "@trevoreyre/autocomplete-vue": "^2.2.0",
     "body-parser": "^1.19.0",

--- a/packages/global/package.json
+++ b/packages/global/package.json
@@ -38,7 +38,7 @@
     "@parameter1/omeda-graphql-client-express": "^0.4.2",
     "@science-medicine-group/package-auth0": "^0.0.0",
     "@science-medicine-group/package-braze": "^1.6.1",
-    "@science-medicine-group/package-zero-bounce": "^1.5.2",
+    "@science-medicine-group/package-zero-bounce": "^0.0.0",
     "@trevoreyre/autocomplete-vue": "^2.2.0",
     "body-parser": "^1.19.0",
     "cheerio": "^1.0.0-rc.10",

--- a/packages/global/start-server.js
+++ b/packages/global/start-server.js
@@ -8,6 +8,7 @@ const auth0 = require('@science-medicine-group/package-auth0');
 const braze = require('@science-medicine-group/package-braze');
 const brazeHooks = require('@science-medicine-group/package-braze/hooks');
 const zeroBounce = require('@science-medicine-group/package-zero-bounce');
+const maxmindGeoIP = require('@science-medicine-group/package-maxmind-geoip');
 
 const document = require('./components/document');
 const components = require('./components');
@@ -48,6 +49,9 @@ module.exports = (options = {}) => {
     onStart: async (app) => {
       if (typeof onStart === 'function') await onStart(app);
       app.set('trust proxy', 'loopback, linklocal, uniquelocal');
+
+      // MaxMind GeoIP setup
+      app.use(maxmindGeoIP);
 
       // Use paginated middleware
       app.use(paginated());

--- a/packages/global/templates/user/profile.marko
+++ b/packages/global/templates/user/profile.marko
@@ -1,4 +1,12 @@
+import { get } from "@parameter1/base-cms-object-path";
+
 $ const { config } = out.global;
+
+$ // Set the IdentityX default country code from the Maxmind data, if present.
+$ // Note: All local IPs will fail lookups!
+$ const maxmindDefault = get(out.global, "res.locals.maxmindData.data.registered_country.iso_code");
+$ const idxOpts = get(out.global, "res.locals.identityX.config.options");
+$ if (maxmindDefault && idxOpts) idxOpts.defaultCountryCode = maxmindDefault;
 
 $ const type = "profile";
 $ const title = `${config.siteName()} Profile`;

--- a/packages/maxmind-geoip/env.js
+++ b/packages/maxmind-geoip/env.js
@@ -1,0 +1,10 @@
+const { cleanEnv, validators } = require('@parameter1/base-cms-env');
+
+const { nonemptystr } = validators;
+
+module.exports = cleanEnv(process.env, {
+  MAXMIND_GEOIP_SERVICE_URL: nonemptystr({
+    desc: 'The MaxMind GeoIP service URL.',
+    default: 'http://maxmind-geoip',
+  }),
+});

--- a/packages/maxmind-geoip/middleware.js
+++ b/packages/maxmind-geoip/middleware.js
@@ -1,0 +1,27 @@
+const { asyncRoute } = require('@parameter1/base-cms-utils');
+const newrelic = require('newrelic');
+const fetch = require('node-fetch');
+const { MAXMIND_GEOIP_SERVICE_URL } = require('./env');
+
+const { log } = console;
+
+module.exports = asyncRoute(async (req, res, next) => {
+  if (res.locals.maxmindData) return;
+  let data = {};
+  try {
+    const response = await fetch(MAXMIND_GEOIP_SERVICE_URL, {
+      method: 'post',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        action: 'country',
+        params: { ip: req.ip },
+      }),
+    });
+    data = await response.json();
+  } catch (e) {
+    log('Error in Maxmind GeoIP lookup!', e);
+    newrelic.noticeError(e);
+  }
+  res.locals.maxmindData = data;
+  next();
+});

--- a/packages/maxmind-geoip/package.json
+++ b/packages/maxmind-geoip/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@science-medicine-group/package-maxmind-geoip",
+  "version": "0.0.0",
+  "description": "MaxMind GeoIP service integration",
+  "repository": "https://github.com/parameter1/science-medicine-group-websites/tree/master/packages/maxmind-geoip",
+  "author": "Josh Worden <josh@parameter1.com>",
+  "license": "MIT",
+  "main": "middleware.js",
+  "scripts": {
+    "lint": "eslint --ext .js --ext .vue --max-warnings 5 ./",
+    "test": "yarn lint"
+  },
+  "dependencies": {
+    "@parameter1/micro": "^1.1.8",
+    "@parameter1/base-cms-env": "^3.0.0",
+    "@parameter1/base-cms-utils": "^3.0.0",
+    "newrelic": "^6.14.0",
+    "node-fetch": "^2.6.1"
+  }
+}

--- a/packages/zero-bounce/package.json
+++ b/packages/zero-bounce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@science-medicine-group/package-zero-bounce",
-  "version": "1.5.2",
+  "version": "0.0.0",
   "description": "ZeroBounce integration",
   "repository": "https://github.com/parameter1/science-medicine-group-websites/tree/master/packages/zero-bounce",
   "author": "Josh Worden <josh@parameter1.com>",


### PR DESCRIPTION
When the user does not have a country specified, pre-populate it from the MaxMind GeoIP service, where possible.

When faked with a `1.1.1.1` express request IP:
<img width="1091" alt="image" src="https://user-images.githubusercontent.com/1778222/199597281-793fb453-1271-4109-b552-70889a91ff1a.png">

When using an internal IP, or otherwise failing to resolve a default country code:
<img width="1071" alt="image" src="https://user-images.githubusercontent.com/1778222/199597359-1fa4fa7f-7f72-41ef-afff-b8c7a2d4b0fc.png">
