### PR TITLE
Enl flow v3

### DIFF
--- a/packages/braze/hooks/on-authentication-success.js
+++ b/packages/braze/hooks/on-authentication-success.js
@@ -1,46 +1,13 @@
-const { getAsArray } = require('@parameter1/base-cms-object-path');
-const { updateIdentityXUser } = require('../utils');
-
 /**
  *
  */
 module.exports = async ({
   user,
   service,
-  authToken,
-  loginSource,
 }) => {
-  // Only set opt-ins from newsletter signup controls, not on every login!
-  if (loginSource !== 'newsletterSignup') return; // @todo verify
-
-  // Skip auto opt-in if the user has already opted in/out
-  const hasAnswered = getAsArray(user, 'customBooleanFieldAnswers').some(ans => ans.hasAnswered === true);
-  if (hasAnswered) return;
-
   const { req } = service;
   const { braze } = req;
 
-  // Mark all subscription group questions as `true`.
-  const questions = await braze.getSubscriptionGroupQuestions(service);
-  const optIns = questions.reduce((obj, q) => ({ ...obj, [q.groupId]: true }), {
-    // Opt out of unconfirmed group!
-    [braze.getUnconfirmedGroupId()]: false,
-  });
-  const answers = questions.map(q => ({ fieldId: q.id, value: true }));
-
-  // Update the IdentityX user profile
-  await updateIdentityXUser(user.email, service, answers);
-
-  // Force the IdX token context to change (for loadActiveContext);
-  service.setToken(authToken.value);
-
-  // Update the Braze subscription data
-  const [, context] = await Promise.all([
-    braze.updateSubscriptions(user.email, user.id, optIns),
-    service.loadActiveContext({ forceQuery: true }),
-  ]);
-
-  // Overwrite the current user data with the info we just set
-  // eslint-disable-next-line no-param-reassign
-  if (context.user) user.customBooleanFieldAnswers = context.user.customBooleanFieldAnswers;
+  // Opt the user out of the 'unconfirmed' group
+  await braze.confirmUser(user.email, user.id);
 };

--- a/packages/braze/hooks/on-login-link-sent.js
+++ b/packages/braze/hooks/on-login-link-sent.js
@@ -6,17 +6,15 @@ module.exports = async ({
   service,
   actionSource,
 }) => {
-  // Only set opt-ins from newsletter signup controls, not on every login!
-  if (actionSource !== 'newsletterSignup') return;
-  // Only opt-in to unconfirmed if the user is not yet verified.
-  if (user.verified) return;
-
   const { req } = service;
   const { braze } = req;
 
-  // Mark all subscription group questions as `true`.
-  const optIns = { [braze.getUnconfirmedGroupId()]: true };
+  // Only set opt-ins from newsletter signup controls, not on every login!
+  if (actionSource !== 'newsletterSignup') return;
 
-  // Update the Braze subscription data
-  await braze.updateSubscriptions(user.email, user.id, optIns);
+  // Only opt-in to unconfirmed if the user is not yet verified.
+  if (user.verified) return;
+
+  // Opt the user into the 'unconfirmed' group
+  await braze.unconfirmUser(user.email, user.id);
 };

--- a/packages/braze/service.js
+++ b/packages/braze/service.js
@@ -98,10 +98,19 @@ class Braze {
   }
 
   /**
-   * Returns the Braze Subscription Group used to hold unconfirmed users
+   * Opts the user into the unconfirmed subscription group
    */
-  getUnconfirmedGroupId() {
-    return this.unconfirmedGroupId;
+  unconfirmUser(email, id) {
+    const { unconfirmedGroupId } = this;
+    return this.updateSubscriptions(email, id, { [unconfirmedGroupId]: true });
+  }
+
+  /**
+   * Opts the user out of the unconfirmed subscription group
+   */
+  confirmUser(email, id) {
+    const { unconfirmedGroupId } = this;
+    return this.updateSubscriptions(email, id, { [unconfirmedGroupId]: false });
   }
 }
 


### PR DESCRIPTION
Included:
- Do not automatically opt-in the user to **ANY** newsletters.
- Add new emails to the unconfirmed subscription group when sending login link from newsletter signup components
- remove emails from the unconfirmed group when authenticating (IdentityX)
- remove emails from the unconfirmed group when authenticating (Auth0)

Not included:
- modification of the Braze user  [email subscription status](https://www.braze.com/docs/api/endpoints/email/post_email_subscription_status/) (subscribed/unsubscribed/opted-in)
- Setting of `email_validation` custom attribute "containing the return value from ZeroBounce"