### PR TITLE
Auth0 resend email support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,11 +22,10 @@ x-env-defaults: &env
   YARN_CACHE_FOLDER: /.yarn-cache
   IDENTITYX_API_TOKEN: ${IDENTITYX_API_TOKEN}
   IDENTITYX_GRAPHQL_URI: ${IDENTITYX_GRAPHQL_URI-https://identity-x.parameter1.com/graphql}
-
+  AUTH0_SERVICE_SECRET: ${AUTH0_SERVICE_SECRET}
   RECAPTCHA_V3_SITE_KEY: ${RECAPTCHA_V3_SITE_KEY}
   RECAPTCHA_V3_SECRET_KEY: ${RECAPTCHA_V3_SECRET_KEY}
   ZERO_BOUNCE_API_KEY: ${ZERO_BOUNCE_API_KEY}
-  AUTH0_SECRET: ${AUTH0_SECRET-this-isnt-very-secure}
   DEBUG: ${DEBUG-}
 
 x-env-local-dev: &env-local-dev
@@ -86,6 +85,7 @@ services:
       SITE_ID: 63038dcdd15c7c4b2e8b4588
       AUTH0_BASEURL: http://www-smg-sab.dev.parameter1.com:9951
       BRAZE_API_KEY: ${BRAZE_API_KEY_SAB}
+      AUTH0_SECRET: ${AUTH0_CLIENT_SECRET_SAB}
     hostname: www-smg-sab.dev.parameter1.com
     ports:
       - "9951:80"
@@ -103,6 +103,7 @@ services:
       SITE_ID: 62fc0ab6475dbd28008b459b
       AUTH0_BASEURL: http://www-smg-lab.dev.parameter1.com:9952
       BRAZE_API_KEY: ${BRAZE_API_KEY_LAB}
+      AUTH0_SECRET: ${AUTH0_CLIENT_SECRET_LAB}
     hostname: www-smg-lab.dev.parameter1.com
     ports:
       - "9952:80"
@@ -120,6 +121,7 @@ services:
       SITE_ID: 63038e29475dbd6a2f8b457e
       AUTH0_BASEURL: http://www-smg-drb.dev.parameter1.com:9953
       BRAZE_API_KEY: ${BRAZE_API_KEY_DRB}
+      AUTH0_SECRET: ${AUTH0_CLIENT_SECRET_DRB}
     hostname: www-smg-drb.dev.parameter1.com
     ports:
       - "9953:80"
@@ -137,6 +139,7 @@ services:
       SITE_ID: 63038e5dd15c7c4b2e8b458a
       AUTH0_BASEURL: http://www-smg-am.dev.parameter1.com:9954
       BRAZE_API_KEY: ${BRAZE_API_KEY_AM}
+      AUTH0_SECRET: ${AUTH0_CLIENT_SECRET_AM}
     hostname: www-smg-am.dev.parameter1.com
     ports:
       - "9954:80"
@@ -154,6 +157,7 @@ services:
       SITE_ID: 63038e96d15c7cc42e8b4581
       AUTH0_BASEURL: http://www-smg-ame.dev.parameter1.com:9955
       BRAZE_API_KEY: ${BRAZE_API_KEY_AM}
+      AUTH0_SECRET: ${AUTH0_CLIENT_SECRET_AM}
     hostname: www-smg-ame.dev.parameter1.com
     ports:
       - "9955:80"
@@ -171,6 +175,7 @@ services:
       SITE_ID: 63038ec219398c102f8b457c
       AUTH0_BASEURL: http://www-smg-ama.dev.parameter1.com:9956
       BRAZE_API_KEY: ${BRAZE_API_KEY_AM}
+      AUTH0_SECRET: ${AUTH0_CLIENT_SECRET_AM}
     hostname: www-smg-ama.dev.parameter1.com
     ports:
       - "9956:80"

--- a/packages/auth0/after-callback.js
+++ b/packages/auth0/after-callback.js
@@ -1,6 +1,5 @@
 const { decode } = require('jsonwebtoken');
-
-const { log } = console;
+const debug = require('debug')('auth0');
 
 /**
  * Syncs Auth0 and IdentityX user states
@@ -24,6 +23,7 @@ module.exports = async (req, _, session) => {
   // Destroy A0 context if no email is present
   const { email, email_verified: ev } = user;
   if (!email || !ev) throw new Error('Auth0 user must provide a verified email address.');
+  debug('user', user);
 
   // Upsert the IdentityX AppUser
   const appUser = await service.createAppUser({ email });
@@ -34,9 +34,9 @@ module.exports = async (req, _, session) => {
       service.impersonateAppUser({ userId: appUser.id }),
       braze.confirmUser(appUser.email, appUser.id),
     ]);
-    log('A0+IdX.cb', 'impersonated', appUser.id);
+    debug('impersonated', appUser.id);
   } catch (e) {
-    log('A0+IdX.cb', 'autherr', e);
+    debug('autherr', e);
     throw e;
   }
 

--- a/packages/auth0/after-callback.js
+++ b/packages/auth0/after-callback.js
@@ -21,9 +21,9 @@ module.exports = async (req, _, session) => {
   if (!user || token) return session;
 
   // Destroy A0 context if no email is present
-  const { email, email_verified: ev } = user;
-  if (!email || !ev) throw new Error('Auth0 user must provide a verified email address.');
+  const { email } = user;
   debug('user', user);
+  if (!email) throw new Error('Auth0 user must provide an email address.');
 
   // Upsert the IdentityX AppUser
   const appUser = await service.createAppUser({ email });

--- a/packages/auth0/browser/.eslintrc.js
+++ b/packages/auth0/browser/.eslintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('../../../eslintrc.browser');

--- a/packages/auth0/browser/index.js
+++ b/packages/auth0/browser/index.js
@@ -1,0 +1,5 @@
+const SendVerificationEmail = () => import(/* webpackChunkName: "auth0-send-verification-email" */ './send-verification-email.vue');
+
+export default (Browser) => {
+  Browser.register('Auth0SendVerificationEmail', SendVerificationEmail);
+};

--- a/packages/auth0/browser/send-verification-email.vue
+++ b/packages/auth0/browser/send-verification-email.vue
@@ -1,0 +1,81 @@
+<template>
+  <div>
+    <form @submit.prevent="handleSubmit">
+      <p>
+        Haven't seen the verification message yet? Click the button below to re-send.
+      </p>
+      <button type="submit" class="btn btn-primary" :disabled="isButtonDisabled">
+        Send verification email
+      </button>
+      <span v-if="didSubmit" class="ml-2">
+        Done! You should receive a message in your inbox shortly.
+      </span>
+      <p v-if="error" class="mt-3 text-danger">
+        An error occurred while processing your request: {{ error }}.
+      </p>
+    </form>
+  </div>
+</template>
+
+<script>
+export default {
+  /**
+   *
+   */
+  props: {
+    endpoint: {
+      type: String,
+      default: '/__auth0/resend-email',
+    },
+    userId: {
+      type: String,
+      required: true,
+    },
+  },
+
+  /**
+   *
+   */
+  data: () => ({
+    error: null,
+    loading: false,
+    didSubmit: false,
+  }),
+
+  /**
+   *
+   */
+  computed: {
+    isButtonDisabled() {
+      return this.loading || (this.didSubmit && !this.error);
+    },
+  },
+
+  /**
+   *
+   */
+  methods: {
+    async handleSubmit() {
+      this.loading = true;
+      this.error = null;
+      try {
+        const r = await fetch(this.endpoint, {
+          method: 'post',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ userId: this.userId }),
+        });
+        if (!r.ok) {
+          const { error } = await r.json();
+          if (error) throw new Error(error);
+          throw new Error(`${r.status} ${r.statusText}`);
+        }
+        this.didSubmit = true;
+      } catch (e) {
+        this.error = e.message;
+      } finally {
+        this.loading = false;
+      }
+    },
+  },
+};
+</script>

--- a/packages/auth0/index.js
+++ b/packages/auth0/index.js
@@ -13,6 +13,7 @@ module.exports = (app, params = {}) => {
     clientID,
     issuerBaseURL,
     clientSecret,
+    serviceConfig,
     // IdentityX Config
     idxConfig,
     idxRouteTemplates,
@@ -23,6 +24,10 @@ module.exports = (app, params = {}) => {
     issuerBaseURL: Joi.string().required().description('The Auth0 tenant URL'),
     idxConfig: Joi.object().required().instance(IdXConfig),
     idxRouteTemplates: Joi.object().required(),
+    serviceConfig: Joi.object({
+      clientId: Joi.string().required().description('The Machine-to-Machine application\'s client ID'),
+      secret: Joi.string().required().description('The machine-to-machine application\'s client secret'),
+    }).required(),
   }), params);
 
   // install identity x
@@ -35,6 +40,9 @@ module.exports = (app, params = {}) => {
     issuerBaseURL,
     secret: clientSecret,
     afterCallback,
+  }, {
+    ...serviceConfig,
+    issuerBaseURL,
   });
 
   // Custom template handling

--- a/packages/auth0/middleware/index.js
+++ b/packages/auth0/middleware/index.js
@@ -4,11 +4,12 @@ const Joi = require('@parameter1/joi');
 const { validate } = require('@parameter1/joi/utils');
 const { asyncRoute } = require('@parameter1/base-cms-utils');
 const identityX = require('./identity-x');
+const Auth0 = require('../service');
 
 /**
  *
  */
-module.exports = (app, params = {}) => {
+module.exports = (app, params = {}, serviceConfig = {}) => {
   const config = validate(Joi.object({
     authRequired: Joi.boolean().default(false),
     auth0Logout: Joi.boolean().default(true),
@@ -20,8 +21,11 @@ module.exports = (app, params = {}) => {
     afterCallback: Joi.function(),
   }), params);
 
-  app.use((req, _, next) => {
-    req.auth0Enabled = true;
+  // Install Auth0 (management service)
+  app.use((req, res, next) => {
+    const service = new Auth0(serviceConfig);
+    req.auth0 = service;
+    res.locals.auth0 = service;
     next();
   });
 

--- a/packages/auth0/middleware/index.js
+++ b/packages/auth0/middleware/index.js
@@ -1,7 +1,7 @@
+const debug = require('debug')('auth0');
 const { auth } = require('express-openid-connect');
 const Joi = require('@parameter1/joi');
 const { validate } = require('@parameter1/joi/utils');
-const { get } = require('@parameter1/base-cms-object-path');
 const { asyncRoute } = require('@parameter1/base-cms-utils');
 const identityX = require('./identity-x');
 
@@ -25,15 +25,28 @@ module.exports = (app, params = {}) => {
     next();
   });
 
+  // Install Auth0 (Express OIDC connect)
   app.use(auth(config));
 
-  app.use((error, req, res, next) => {
-    if (error.error === 'access_denied' && error.error_description === 'Please verify your email address to continue.') {
-      const returnTo = get(req, 'openidState.returnTo');
-      res.redirect(302, `/user/auth0-db-email-verification${returnTo ? `?returnTo=${returnTo}` : ''}`);
+  // Enforce user logout/notice when email is unconfirmed.
+  app.use(asyncRoute(async (req, res, next) => {
+    const { user } = req.oidc;
+    const isAuthenticated = req.oidc.isAuthenticated();
+    const isIdentified = Boolean(req.identityX.token);
+    const canRedirect = !/^\/user\/auth0-db-email-verification/.test(req.url);
+    if (isAuthenticated && isIdentified && canRedirect) {
+      debug('Checking email verification', user);
+      if (user && user.requireVerification) {
+        // Log out of IdX
+        await req.identityX.logoutAppUser(); // @todo fix upstream error when no token present
+        // Redirect to verification notice
+        const usp = new URLSearchParams({ userId: user.sub, returnTo: req.url });
+        debug('log out/redirect!', usp);
+        res.redirect(302, `/user/auth0-db-email-verification?${usp}`);
+      }
     }
-    next(error); // invoke next middleware
-  });
+    next();
+  }));
 
   // Redirect after login if `returnTo` URL parameter is present.
   if (config.routes.login === false) {

--- a/packages/auth0/middleware/index.js
+++ b/packages/auth0/middleware/index.js
@@ -1,4 +1,5 @@
 const debug = require('debug')('auth0');
+const { json } = require('express');
 const { auth } = require('express-openid-connect');
 const Joi = require('@parameter1/joi');
 const { validate } = require('@parameter1/joi/utils');
@@ -74,6 +75,16 @@ module.exports = (app, params = {}, serviceConfig = {}) => {
       res.oidc.logout();
     }));
   }
+
+  // Handle resend email request
+  app.post('/__auth0/resend-email', json(), asyncRoute(async (req, res) => {
+    const { auth0, body } = req;
+    const { userId } = body;
+    debug('resend email', userId);
+    const r = await auth0.sendVerificationEmail(userId); // @todo retrieve user id
+    debug('response', r);
+    res.json(r);
+  }));
 
   // Load the IdentityX integration
   app.use(identityX);

--- a/packages/auth0/package.json
+++ b/packages/auth0/package.json
@@ -16,7 +16,8 @@
     "@parameter1/joi": "^1.2.10",
     "debug": "^4.1.1",
     "express-openid-connect": "^2.8.0",
-    "jsonwebtoken": "^8.5.1"
+    "jsonwebtoken": "^8.5.1",
+    "node-fetch": "^2.6.6"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/auth0/package.json
+++ b/packages/auth0/package.json
@@ -14,6 +14,7 @@
     "@parameter1/base-cms-object-path": "^3.0.0",
     "@parameter1/base-cms-utils": "^3.0.0",
     "@parameter1/joi": "^1.2.10",
+    "debug": "^4.1.1",
     "express-openid-connect": "^2.8.0",
     "jsonwebtoken": "^8.5.1"
   },

--- a/packages/auth0/package.json
+++ b/packages/auth0/package.json
@@ -15,11 +15,9 @@
     "@parameter1/base-cms-utils": "^3.0.0",
     "@parameter1/joi": "^1.2.10",
     "debug": "^4.1.1",
+    "express": "^4.17.1",
     "express-openid-connect": "^2.8.0",
     "jsonwebtoken": "^8.5.1",
     "node-fetch": "^2.6.6"
-  },
-  "publishConfig": {
-    "access": "public"
   }
 }

--- a/packages/auth0/service.js
+++ b/packages/auth0/service.js
@@ -1,0 +1,86 @@
+const Joi = require('@parameter1/joi');
+const { validate } = require('@parameter1/joi/utils');
+const fetch = require('node-fetch');
+const debug = require('debug')('auth0');
+
+class Auth0 {
+  constructor(params = {}) {
+    const {
+      clientId,
+      issuerBaseURL,
+      secret,
+    } = validate(Joi.object({
+      clientId: Joi.string().required().description('The Auth0 client id'),
+      issuerBaseURL: Joi.string().uri().description('The Auth0 tenant URL'),
+      secret: Joi.string().required().description('The Auth0 client secret'),
+    }), params);
+    this.clientId = clientId;
+    this.issuerBaseURL = issuerBaseURL;
+    this.secret = secret;
+  }
+
+  /**
+   * Handles the internal short-lived authentication token
+   */
+  async getToken() {
+    if (!this.token) this.token = await this.fetchToken();
+    return this.token;
+  }
+
+  /**
+   * Retrieves a new Management API token
+   */
+  async fetchToken() {
+    const url = `${this.issuerBaseURL}/oauth/token`;
+    const r = await fetch(url, {
+      method: 'post',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        grant_type: 'client_credentials',
+        client_id: this.clientId,
+        client_secret: this.secret,
+        audience: `${this.issuerBaseURL}/api/v2/`,
+      }),
+    });
+    const response = await r.json();
+    debug('fetchToken', response);
+    if (!r.ok || !response.access_token) throw new Error(`API request was unsuccessful: ${r.status} ${r.statusText}`);
+    return response.access_token;
+  }
+
+  /**
+   * Makes a request against the Auth0 API
+   * @param {*} endpoint The A0 APi endpoint to request
+   * @param {*} opts Additional fetch args
+   * @returns Promise
+   */
+  async request(endpoint, opts = {}) {
+    const method = opts.method || 'post';
+    const token = await this.getToken();
+    const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
+    const url = `${this.issuerBaseURL}/${endpoint}`;
+    const r = await fetch(url, { method, headers, ...opts || {} });
+    const response = await r.json();
+    if (!r.ok) {
+      debug(`${method.toUpperCase()} ${url} ERR`, { headers, ...opts || {}, response });
+      if (response.message) throw new Error(response.message);
+      throw new Error(`API request was unsuccessful: ${r.status} ${r.statusText}`);
+    }
+    debug(`${method.toUpperCase()} ${url} OK`, { headers, ...opts || {}, response });
+    return response;
+  }
+
+  /**
+   * Sends a verification email to the specified user
+   * @see https://auth0.com/docs/api/management/v2#!/Jobs/post_verification_email
+   * @param {String} userId The Auth0 user id (idToken.sub)
+   * @returns Promise
+   */
+  sendVerificationEmail(userId) {
+    return this.request('api/v2/jobs/verification-email', {
+      body: JSON.stringify({ user_id: userId, client_id: this.clientId }),
+    });
+  }
+}
+
+module.exports = Auth0;

--- a/packages/auth0/templates/db-email-verification.marko
+++ b/packages/auth0/templates/db-email-verification.marko
@@ -1,5 +1,5 @@
 $ const { config, req } = out.global;
-$ const { returnTo } = req.query;
+$ const { returnTo, userId } = req.query;
 
 $ const type = "authentication";
 $ const title = "Email Verification Required";
@@ -16,6 +16,9 @@ $ const description = `Complete your ${config.siteName()} Profile`;
           <p>After clicking the verification link, <a href=`/login?returnTo=${returnTo}`>click here</a> to re-authenticate and return to the previous page.</p>
         </if>
         <p>If you need assistance, please reach out to us through our <a href="/page/contact-us">contact form</a>.</p>
+        <if(userId)>
+          <marko-web-browser-component name="Auth0SendVerificationEmail" props={ userId } />
+        </if>
       </@section>
     </marko-web-page-wrapper>
   </@page>

--- a/packages/braze/service.js
+++ b/packages/braze/service.js
@@ -23,19 +23,17 @@ class Braze {
   }
 
   async request(endpoint, opts = {}) {
-    debug('request', `${this.host}/${endpoint}`, { method: 'post', headers: this.headers, ...opts || {} });
-    const r = await fetch(`${this.host}/${endpoint}`, {
-      method: 'post',
-      headers: this.headers,
-      ...opts || {},
-    });
+    const method = opts.method || 'post';
+    const { headers } = this;
+    const url = `${this.host}/${endpoint}`;
+    const r = await fetch(url, { method, headers, ...opts || {} });
     const response = await r.json();
     if (!r.ok) {
-      debug('error', response);
+      debug(`${method.toUpperCase()} ${url} ERR`, { headers, ...opts || {}, response });
       if (response.message) throw new Error(response.message);
       throw new Error(`API request was unsuccessful: ${r.status} ${r.statusText}`);
     }
-    debug('response', response);
+    debug(`${method.toUpperCase()} ${url} OK`, { headers, ...opts || {}, response });
     return response;
   }
 

--- a/packages/global/browser/index.js
+++ b/packages/global/browser/index.js
@@ -1,5 +1,6 @@
 
 import MonoRail from '@parameter1/base-cms-marko-web-theme-monorail/browser';
+import Auth0 from '@science-medicine-group/package-auth0/browser';
 import Braze from '@science-medicine-group/package-braze/browser';
 import FormLogin from './form-login.vue';
 import Rudderstack from './rudderstack.vue';
@@ -19,6 +20,7 @@ export default (Browser) => {
   Browser.register('GlobalSiteNewsletterMenu', GlobalSiteNewsletterMenu, {
     provide: { EventBus },
   });
+  Auth0(Browser);
   Braze(Browser);
 
   // Rudderstack identification

--- a/packages/global/components/auth0/access.marko
+++ b/packages/global/components/auth0/access.marko
@@ -1,5 +1,5 @@
 $ const { req, site } = out.global;
-$ const isEnabled = req.auth0Enabled || false;
+$ const isEnabled = req.auth0 || false;
 $ const hasUser = req.oidc ? req.oidc.isAuthenticated() : false;
 $ const canAccess = (input.requiresRegistration === false) || hasUser;
 

--- a/packages/global/components/auth0/context.marko
+++ b/packages/global/components/auth0/context.marko
@@ -1,5 +1,5 @@
 $ const { req, site } = out.global;
-$ const isEnabled = req.auth0Enabled || false;
+$ const isEnabled = req.auth0 || false;
 $ const hasUser = req.oidc ? req.oidc.isAuthenticated() : false;
 
 <${input.renderBody} is-enabled=isEnabled has-user=hasUser />

--- a/packages/zero-bounce/service.js
+++ b/packages/zero-bounce/service.js
@@ -34,18 +34,16 @@ class ZeroBounce {
    * @returns Promise
    */
   async request(endpoint, opts = {}) {
-    debug('request', `${this.apiHost}/${endpoint}`, { method: 'get', ...opts || {} });
-    const r = await fetch(`${this.apiHost}/${endpoint}`, {
-      method: 'get',
-      ...opts || {},
-    });
+    const method = opts.method || 'get';
+    const url = `${this.apiHost}/${endpoint}`;
+    const r = await fetch(url, { method, ...opts || {} });
     const response = await r.json();
     if (!r.ok) {
-      debug('error', response);
+      debug(`${method.toUpperCase()} ${url} ERR`, { ...opts || {}, response });
       if (response.message) throw new Error(response.message);
       throw new Error(`API request was unsuccessful: ${r.status} ${r.statusText}`);
     }
-    debug('response', response);
+    debug(`${method.toUpperCase()} ${url} ERR`, { ...opts || {}, response });
     return response;
   }
 

--- a/sites/auntminnie.com/config/auth0.js
+++ b/sites/auntminnie.com/config/auth0.js
@@ -3,4 +3,8 @@ module.exports = {
   clientID: 'vQCESj6ejmyuZTQWEHAzVB2yecXbdwZ4',
   clientSecret: process.env.AUTH0_SECRET,
   issuerBaseURL: 'https://dev-scienceandmedicinegroup.us.auth0.com',
+  serviceConfig: {
+    clientId: 'cHNiQqZno6Pjjbs6osQRwS5uPqhPj86h',
+    secret: process.env.AUTH0_SERVICE_SECRET,
+  },
 };

--- a/sites/auntminnieasia.com/config/auth0.js
+++ b/sites/auntminnieasia.com/config/auth0.js
@@ -3,4 +3,8 @@ module.exports = {
   clientID: 'ZYZ71w4bPDDXkWjrafFH6casl7E0RWQH',
   clientSecret: process.env.AUTH0_SECRET,
   issuerBaseURL: 'https://dev-scienceandmedicinegroup.us.auth0.com',
+  serviceConfig: {
+    clientId: 'cHNiQqZno6Pjjbs6osQRwS5uPqhPj86h',
+    secret: process.env.AUTH0_SERVICE_SECRET,
+  },
 };

--- a/sites/auntminnieeurope.com/config/auth0.js
+++ b/sites/auntminnieeurope.com/config/auth0.js
@@ -3,4 +3,8 @@ module.exports = {
   clientID: 'tWQ42oVRw9JH1WBLepLvNASMPjzzNrBf',
   clientSecret: process.env.AUTH0_SECRET,
   issuerBaseURL: 'https://dev-scienceandmedicinegroup.us.auth0.com',
+  serviceConfig: {
+    clientId: 'cHNiQqZno6Pjjbs6osQRwS5uPqhPj86h',
+    secret: process.env.AUTH0_SERVICE_SECRET,
+  },
 };

--- a/sites/drbicuspid.com/config/auth0.js
+++ b/sites/drbicuspid.com/config/auth0.js
@@ -3,4 +3,8 @@ module.exports = {
   clientID: '8aHKTbVEAMFdtF3S2sA67zoprlfT2TVw',
   clientSecret: process.env.AUTH0_SECRET,
   issuerBaseURL: 'https://dev-scienceandmedicinegroup.us.auth0.com',
+  serviceConfig: {
+    clientId: 'cHNiQqZno6Pjjbs6osQRwS5uPqhPj86h',
+    secret: process.env.AUTH0_SERVICE_SECRET,
+  },
 };

--- a/sites/labpulse.com/config/auth0.js
+++ b/sites/labpulse.com/config/auth0.js
@@ -3,4 +3,8 @@ module.exports = {
   clientID: '8aHKTbVEAMFdtF3S2sA67zoprlfT2TVw',
   clientSecret: process.env.AUTH0_SECRET,
   issuerBaseURL: 'https://dev-scienceandmedicinegroup.us.auth0.com',
+  serviceConfig: {
+    clientId: 'cHNiQqZno6Pjjbs6osQRwS5uPqhPj86h',
+    secret: process.env.AUTH0_SERVICE_SECRET,
+  },
 };

--- a/sites/scienceboard.net/config/auth0.js
+++ b/sites/scienceboard.net/config/auth0.js
@@ -3,4 +3,8 @@ module.exports = {
   clientID: 'OOs6hrCy6U8fGdshDPTTRutVhF4Vs86g',
   clientSecret: process.env.AUTH0_SECRET,
   issuerBaseURL: 'https://dev-scienceandmedicinegroup.us.auth0.com',
+  serviceConfig: {
+    clientId: 'cHNiQqZno6Pjjbs6osQRwS5uPqhPj86h',
+    secret: process.env.AUTH0_SERVICE_SECRET,
+  },
 };


### PR DESCRIPTION
Rework authentication flow to support intercepting a database user after login, rather than aborting the login, if they do not have a validated email address.

This requires the following Auth0 changes:
- [x] Create M2M application in SMG tenant
- [x] Add client ID to configs
- [x] Add secret to Rancher configs
- [ ] [after deployment] Alter [Auth0 login action](https://manage.auth0.com/dashboard/us/parameter1/actions/library/details/12a954bd-dd6a-4ad3-aed0-6245e1b69081) to the following:
```diff
 exports.onExecutePostLogin = async (event, api) => {	
   const { identities, email_verified } = event.user;	
   const isDbUser = identities.some((id) => id.isSocial === false);		
+  api.idToken.setCustomClaim(`isDbUser`, isDbUser);
   if (!email_verified && isDbUser) {	
-    // @todo, how to retrieve user id in error state?	
-    api.access.deny(`Please verify your email address to continue.`);
+    // Set custom claim to id token to make available
+    api.idToken.setCustomClaim(`requireVerification`, true);
   }
 };
```

Landing page with verification button
![image](https://user-images.githubusercontent.com/1778222/200077338-56579c9e-08a9-4cca-8174-c10b91f65b85.png)

After clicking submit
![image](https://user-images.githubusercontent.com/1778222/200077375-1cc08957-2816-40ba-93a5-019ce31166b3.png)
