### PR TITLE
Add no email/logout template

### DIFF
--- a/packages/auth0/after-callback.js
+++ b/packages/auth0/after-callback.js
@@ -9,7 +9,7 @@ const debug = require('debug')('auth0');
  * @param {Object} session
  * @returns Object the Auth0 user session object
  */
-module.exports = async (req, _, session) => {
+module.exports = async (req, res, session) => {
   // Only handle if Auth0 & IdentityX are loaded
   if (!req.identityX) throw new Error('IdentityX must be enabled and configured!');
 
@@ -23,7 +23,10 @@ module.exports = async (req, _, session) => {
   // Destroy A0 context if no email is present
   const { email } = user;
   debug('user', user);
-  if (!email) throw new Error('Auth0 user must provide an email address.');
+  if (!email) {
+    res.redirect('/user/auth0-no-email');
+    throw new Error('Auth0 user must provide an email address.');
+  }
 
   // Upsert the IdentityX AppUser
   const appUser = await service.createAppUser({ email });

--- a/packages/auth0/index.js
+++ b/packages/auth0/index.js
@@ -39,4 +39,5 @@ module.exports = (app, params = {}) => {
 
   // Custom template handling
   app.get('/user/auth0-db-email-verification', (_, res) => { res.marko(templates.dbEmailVerification); });
+  app.get('/user/auth0-no-email', (_, res) => { res.marko(templates.noEmail); });
 };

--- a/packages/auth0/templates/index.js
+++ b/packages/auth0/templates/index.js
@@ -1,5 +1,7 @@
 const dbEmailVerification = require('./db-email-verification');
+const noEmail = require('./no-email');
 
 module.exports = {
   dbEmailVerification,
+  noEmail,
 };

--- a/packages/auth0/templates/no-email.marko
+++ b/packages/auth0/templates/no-email.marko
@@ -1,0 +1,21 @@
+$ const { config, req, site } = out.global;
+
+$ const type = "authentication";
+$ const title = "Unable to log in";
+$ const description = `Complete your ${config.siteName()} Profile`;
+$ const { baseURL, issuerBaseURL, clientID } = site.getAsObject('auth0');
+$ const returnTo = encodeURIComponent(`${baseURL}/login`);
+
+<marko-web-default-page-layout type=type title=title description=title>
+  <@page>
+    <marko-web-page-wrapper>
+      <@section>
+        <h1 class="page-wrapper__title">${title}</h1>
+        <p class="lead">Sorry, but your login could not be completed!</p>
+        <p>To log in to ${site.name}, you need to provide a valid email address, but your social provider settings have prevented this.</p>
+        <p>To try again, <a href=`${issuerBaseURL}/v2/logout?client_id=${clientID}&returnTo=${returnTo}`>click here</a> to log in with another provider.</p>
+        <p>If you need assistance, please reach out to us through our <a href="/page/contact-us">contact form</a>.</p>
+      </@section>
+    </marko-web-page-wrapper>
+  </@page>
+</marko-web-default-page-layout>

--- a/packages/auth0/templates/no-email.marko
+++ b/packages/auth0/templates/no-email.marko
@@ -12,7 +12,7 @@ $ const returnTo = encodeURIComponent(`${baseURL}/login`);
       <@section>
         <h1 class="page-wrapper__title">${title}</h1>
         <p class="lead">Sorry, but your login could not be completed!</p>
-        <p>To log in to ${site.name}, you need to provide a valid email address, but your social provider settings have prevented this.</p>
+        <p>To log in to ${config.siteName()}, you need to provide a valid email address, but your social provider settings have prevented this.</p>
         <p>To try again, <a href=`${issuerBaseURL}/v2/logout?client_id=${clientID}&returnTo=${returnTo}`>click here</a> to log in with another provider.</p>
         <p>If you need assistance, please reach out to us through our <a href="/page/contact-us">contact form</a>.</p>
       </@section>

--- a/packages/global/middleware/newsletter-state.js
+++ b/packages/global/middleware/newsletter-state.js
@@ -3,11 +3,12 @@ const { get } = require('@parameter1/base-cms-object-path');
 const cookieName = 'enlPrompted';
 const newsletterState = ({ setCookie = true } = {}) => (req, res, next) => {
   const hasCookie = Boolean(get(req, `cookies.${cookieName}`));
+  const hasUser = Boolean(get(req, 'cookies.__idx'));
   const utmMedium = get(req, 'query.utm_medium');
   const olyEncId = get(req, 'query.oly_enc_id');
   const disabled = get(req, 'query.newsletterDisabled');
   const fromEmail = utmMedium === 'email' || olyEncId || false;
-  const canBeInitiallyExpanded = !(hasCookie || fromEmail || disabled);
+  const canBeInitiallyExpanded = !(hasCookie || fromEmail || hasUser || disabled);
   const initiallyExpanded = (setCookie === true) && canBeInitiallyExpanded;
 
   // Expire in 14 days (2yr if already signed up)


### PR DESCRIPTION
When logging in with Facebook and unchecking `email` permission (or otherwise not providing an email address), redirect the user to a custom landing page advising them of the problem and how to resolve it. Per Lisa, don't bother with the social provider re-prompt for now, just allow them to log out and select a different provider.
<img width="1099" alt="image" src="https://user-images.githubusercontent.com/1778222/202575258-85535075-f2ad-47e2-bcd3-1ac091f278d7.png">
