### PR TITLE
Update site-menu css to fix css transition/transform

### DIFF
--- a/packages/global/scss/components/_site-menu.scss
+++ b/packages/global/scss/components/_site-menu.scss
@@ -1,0 +1,17 @@
+.site-menu {
+  $self: &;
+  opacity: 1;
+
+  @media (min-width: $skin-desktop-menu-breakpoint) {
+    width: 100%;
+    height: 0;
+    transition: height 0.5s ease-out;
+    transform: none;
+
+    &--open {
+      height: initial;
+      transition: height 0.5s ease-in;
+      transform: none;
+    }
+  }
+}

--- a/packages/global/scss/core.scss
+++ b/packages/global/scss/core.scss
@@ -20,6 +20,7 @@
 @import "./components/directory-section-feed";
 @import "./components/newsletter-pushdown";
 @import "./components/site-footer";
+@import "./components/site-menu";
 @import "./components/site-navbar";
 @import "./components/site-navbar-c";
 @import "./components/user";


### PR DESCRIPTION
This will update the header to stay in position and just expand instead of sliding in over the site logo.