### PR TITLE
Braze user identification

### DIFF
--- a/packages/braze/index.js
+++ b/packages/braze/index.js
@@ -13,6 +13,7 @@ module.exports = (app, params = {}) => {
       email: 'email',
     }).description('The Braze fields that should be mapped to IdentityX fields.'),
     unconfirmedGroupId: Joi.string().required().description('The Braze Subscription Group ID to use for unconfirmed users'),
+    appGroupId: Joi.string().required().description('The Braze App Groupo ID to use.'),
   }), params, { allowUnknown: true });
 
   const service = new Braze(args);

--- a/packages/braze/index.js
+++ b/packages/braze/index.js
@@ -1,5 +1,6 @@
 const Joi = require('@parameter1/joi');
 const { validate } = require('@parameter1/joi/utils');
+const setIdCookies = require('./middleware/set-id-cookies');
 const Braze = require('./service');
 
 module.exports = (app, params = {}) => {
@@ -21,4 +22,7 @@ module.exports = (app, params = {}) => {
     res.locals.braze = service;
     next();
   });
+
+  // Set the internal and external id cookies if present in the URL.
+  app.use(setIdCookies);
 };

--- a/packages/braze/middleware/set-id-cookies.js
+++ b/packages/braze/middleware/set-id-cookies.js
@@ -1,0 +1,41 @@
+const tokenCookie = require('@parameter1/base-cms-marko-web-identity-x/utils/token-cookie');
+
+const COOKIE_INTERNAL = 'braze_int_id';
+const COOKIE_EXTERNAL = 'braze_ext_id';
+
+/**
+ * Handles the `braze_<ext|int>_id` query parameters.
+ */
+module.exports = (req, res, next) => {
+  const curExternalId = req.cookies[COOKIE_EXTERNAL];
+  const curInternalId = req.cookies[COOKIE_INTERNAL];
+  const idxUserExists = tokenCookie.exists(req);
+  const {
+    [COOKIE_INTERNAL]: newExternalId,
+    [COOKIE_EXTERNAL]: newInternalId,
+    ...q
+  } = req.query;
+
+  // Only process requests with at least one matching query parameter
+  if (!newExternalId && !newInternalId) return next();
+
+  // If the user isn't logged in or doesn't have an external id cookie, set it.
+  if (newExternalId && (!curExternalId || !idxUserExists)) {
+    const options = { maxAge: 60 * 60 * 24 * 365, httpOnly: false };
+    res.cookie(COOKIE_EXTERNAL, newExternalId, options);
+  }
+  // If the user isn't logged in or doesn't have an internal id cookie, set it.
+  if (newInternalId && (!curInternalId || !idxUserExists)) {
+    const options = { maxAge: 60 * 60 * 24 * 365, httpOnly: false };
+    res.cookie(COOKIE_INTERNAL, newInternalId, options);
+  }
+
+  // Strip the query parameters from the request.
+  if (newExternalId || newInternalId) {
+    const params = (new URLSearchParams(q)).toString();
+    const redirectTo = `${req.path}${params ? `?${params}` : ''}`;
+    return res.redirect(302, redirectTo);
+  }
+
+  return next();
+};

--- a/packages/braze/package.json
+++ b/packages/braze/package.json
@@ -16,6 +16,7 @@
     "@parameter1/base-cms-env": "^3.0.0",
     "@parameter1/base-cms-marko-web": "^3.14.0",
     "@parameter1/base-cms-marko-web-gtm": "^3.7.3",
+    "@parameter1/base-cms-marko-web-identity-x": "^3.15.1",
     "@parameter1/base-cms-marko-web-recaptcha": "^3.0.0",
     "@parameter1/base-cms-object-path": "^3.0.0",
     "@parameter1/base-cms-utils": "^3.0.0",

--- a/packages/braze/service.js
+++ b/packages/braze/service.js
@@ -11,6 +11,7 @@ class Braze {
     tenant,
     fieldMap,
     unconfirmedGroupId,
+    appGroupId,
   } = {}) {
     this.host = apiHost;
     this.tenant = tenant;
@@ -20,6 +21,7 @@ class Braze {
       authorization: `Bearer ${apiKey}`,
     };
     this.unconfirmedGroupId = unconfirmedGroupId;
+    this.appGroupId = appGroupId;
   }
 
   async request(endpoint, opts = {}) {

--- a/packages/global/config/braze.js
+++ b/packages/global/config/braze.js
@@ -5,9 +5,11 @@ module.exports = (params = {}) => {
   const {
     siteName,
     unconfirmedGroupId,
+    appGroupId,
   } = validate(Joi.object({
     siteName: Joi.string().required().description('The Braze site membership identifier.'),
     unconfirmedGroupId: Joi.string().required().description('The Braze Subscription Group ID to use for unconfirmed users'),
+    appGroupId: Joi.string().required().description('The Braze App Groupo ID to use.'),
   }), params);
 
   return {
@@ -25,6 +27,7 @@ module.exports = (params = {}) => {
       organization: 'org_name',
     },
     unconfirmedGroupId,
+    appGroupId,
     onUserProfileUpdateFormatter: async ({ payload = [] }) => ({
       ...payload,
       site_membership: { add: siteName },

--- a/packages/global/middleware/gam-tracker.js
+++ b/packages/global/middleware/gam-tracker.js
@@ -1,0 +1,40 @@
+const { set } = require('@parameter1/base-cms-object-path');
+const { asyncRoute } = require('@parameter1/base-cms-utils');
+const fetch = require('node-fetch');
+
+module.exports = asyncRoute(async (req, res, next) => {
+  try {
+    const { GAM_TRACK_API_KEY } = process.env;
+    if (!GAM_TRACK_API_KEY) return next();
+    const { identityX } = res.locals;
+    if (!identityX) return next();
+    const context = await identityX.loadActiveContext();
+    const { application, user } = context;
+    if (!application || !user) return next();
+
+    const r = await fetch('https://api.gt.parameter1.dev', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-api-key': GAM_TRACK_API_KEY },
+      body: JSON.stringify({
+        action: 'encrypt',
+        params: {
+          identities: [{
+            provider: 'identity-x',
+            tenant: application.id,
+            entityType: 'app-user',
+            id: user.id,
+          }],
+        },
+      }),
+    });
+    if (!r.ok) throw new Error('Bad fetch response');
+    const { data } = await r.json();
+    set(res.locals, 'gamTrackTargeting', data);
+    return next();
+  } catch (e) {
+    // @todo log this, don't break the request.
+    const { error } = console;
+    error('GAM TRACKER ERROR!', e);
+    return next();
+  }
+});

--- a/packages/global/middleware/gam-tracker.js
+++ b/packages/global/middleware/gam-tracker.js
@@ -1,34 +1,54 @@
 const { set } = require('@parameter1/base-cms-object-path');
 const { asyncRoute } = require('@parameter1/base-cms-utils');
 const fetch = require('node-fetch');
-const tokenCookie = require('@parameter1/base-cms-marko-web-identity-x/utils/token-cookie');
-
 
 module.exports = asyncRoute(async (req, res, next) => {
   try {
     const { GAM_TRACK_API_KEY } = process.env;
     if (!GAM_TRACK_API_KEY) return next();
-    const { identityX } = res.locals;
-    if (!identityX) return next();
-    const idxAppId = identityX.config.appId;
-    const idxUserId = tokenCookie.getFrom(req);
-    if (!idxAppId || !idxUserId) return next();
+    const { identityX, braze } = res.locals;
+    if (!identityX || !braze) return next();
+    const identities = [];
+
+    const { application, user } = await identityX.loadActiveContext();
+    if (application.id && user.id) {
+      identities.push({
+        provider: 'identity-x',
+        tenant: application.id,
+        entityType: 'app-user',
+        id: user.id,
+      });
+    }
+
+    const brazeAppGroupId = braze.appGroupId;
+    const brazeExtId = req.cookies.braze_ext_id;
+    if (brazeAppGroupId && brazeExtId) {
+      identities.push({
+        provider: 'braze',
+        tenant: brazeAppGroupId,
+        entityType: 'external',
+        id: brazeExtId,
+      });
+    }
+    const brazeIntId = req.cookies.braze_int_id;
+    if (brazeAppGroupId && brazeIntId) {
+      identities.push({
+        provider: 'braze',
+        tenant: brazeAppGroupId,
+        entityType: 'internal',
+        id: brazeIntId,
+      });
+    }
+
+    // Bail if no identity is available
+    if (!identities.length) return next();
 
     const r = await fetch('https://api.gt.parameter1.dev', {
       method: 'POST',
       headers: { 'content-type': 'application/json', 'x-api-key': GAM_TRACK_API_KEY },
       body: JSON.stringify({
         action: 'encrypt',
-        params: {
-          identities: [
-            ...(idxUserId ? [{
-              provider: 'identity-x',
-              tenant: idxAppId,
-              entityType: 'app-user',
-              id: idxUserId,
-            }] : []),
-          ],
-        },
+        params: { identities },
       }),
     });
     if (!r.ok) throw new Error('Bad fetch response');

--- a/packages/global/start-server.js
+++ b/packages/global/start-server.js
@@ -4,13 +4,11 @@ const { set, get, getAsObject } = require('@parameter1/base-cms-object-path');
 const loadInquiry = require('@parameter1/base-cms-marko-web-inquiry');
 const htmlSitemapPagination = require('@parameter1/base-cms-marko-web-html-sitemap/middleware/paginated');
 const companySearchHandler = require('@parameter1/base-cms-marko-web-theme-monorail/routes/company-search');
-const { asyncRoute } = require('@parameter1/base-cms-utils');
 const auth0 = require('@science-medicine-group/package-auth0');
 const braze = require('@science-medicine-group/package-braze');
 const brazeHooks = require('@science-medicine-group/package-braze/hooks');
 const zeroBounce = require('@science-medicine-group/package-zero-bounce');
 const maxmindGeoIP = require('@science-medicine-group/package-maxmind-geoip');
-const fetch = require('node-fetch');
 
 const document = require('./components/document');
 const components = require('./components');
@@ -18,6 +16,7 @@ const fragments = require('./fragments');
 const idxRouteTemplates = require('./templates/user');
 const sharedRoutes = require('./routes');
 const paginated = require('./middleware/paginated');
+const gamTracker = require('./middleware/gam-tracker');
 const oembedHandler = require('./oembed-handler');
 const redirectHandler = require('./redirect-handler');
 
@@ -87,42 +86,8 @@ module.exports = (options = {}) => {
       const i18n = v => v;
       set(app.locals, 'i18n', options.i18n || i18n);
 
-      app.use(asyncRoute(async (req, res, next) => {
-        try {
-          const { GAM_TRACK_API_KEY } = process.env;
-          if (!GAM_TRACK_API_KEY) return next();
-          const { identityX } = res.locals;
-          if (!identityX) return next();
-          const context = await identityX.loadActiveContext();
-          const { application, user } = context;
-          if (!application || !user) return next();
-
-          const r = await fetch('https://api.gt.parameter1.dev', {
-            method: 'POST',
-            headers: { 'content-type': 'application/json', 'x-api-key': GAM_TRACK_API_KEY },
-            body: JSON.stringify({
-              action: 'encrypt',
-              params: {
-                identities: [{
-                  provider: 'identity-x',
-                  tenant: application.id,
-                  entityType: 'app-user',
-                  id: user.id,
-                }],
-              },
-            }),
-          });
-          if (!r.ok) throw new Error('Bad fetch response');
-          const { data } = await r.json();
-          set(res.locals, 'gamTrackTargeting', data);
-          return next();
-        } catch (e) {
-          // @todo log this, don't break the request.
-          const { error } = console;
-          error('GAM TRACKER ERROR!', e);
-          return next();
-        }
-      }));
+      // Must always be loaded last!
+      app.use(gamTracker);
     },
     onAsyncBlockError: e => newrelic.noticeError(e),
     redirectHandler: redirectHandler(options.redirectHandler),

--- a/sites/auntminnie.com/config/braze.js
+++ b/sites/auntminnie.com/config/braze.js
@@ -6,4 +6,5 @@ log('Create/set unconfirmedGroupId!');
 module.exports = config({
   siteName: 'AM',
   unconfirmedGroupId: '~not-set~',
+  appGroupId: '634d675d1118243d1113480e',
 });

--- a/sites/auntminnieasia.com/config/braze.js
+++ b/sites/auntminnieasia.com/config/braze.js
@@ -6,4 +6,5 @@ log('Create/set unconfirmedGroupId!');
 module.exports = config({
   siteName: 'AMA',
   unconfirmedGroupId: '~not-set~',
+  appGroupId: '634d675d1118243d1113480e',
 });

--- a/sites/auntminnieeurope.com/config/braze.js
+++ b/sites/auntminnieeurope.com/config/braze.js
@@ -6,4 +6,5 @@ log('Create/set unconfirmedGroupId!');
 module.exports = config({
   siteName: 'AME',
   unconfirmedGroupId: '~not-set~',
+  appGroupId: '634d675d1118243d1113480e',
 });

--- a/sites/drbicuspid.com/config/braze.js
+++ b/sites/drbicuspid.com/config/braze.js
@@ -6,4 +6,5 @@ log('Create/set unconfirmedGroupId!');
 module.exports = config({
   siteName: 'DrBicuspid',
   unconfirmedGroupId: '~not-set~',
+  appGroupId: '634d67c3ee91fe5375c3bcac',
 });

--- a/sites/labpulse.com/config/braze.js
+++ b/sites/labpulse.com/config/braze.js
@@ -3,4 +3,5 @@ const config = require('@science-medicine-group/package-global/config/braze');
 module.exports = config({
   siteName: 'LabPulse',
   unconfirmedGroupId: '75f0a01f-de6b-4b8c-95d9-a0e516280aa8',
+  appGroupId: '6321cf49247c426e9256f6d0',
 });

--- a/sites/scienceboard.net/config/braze.js
+++ b/sites/scienceboard.net/config/braze.js
@@ -6,4 +6,5 @@ log('Create/set unconfirmedGroupId!');
 module.exports = config({
   siteName: 'SAB',
   unconfirmedGroupId: '~not-set~',
+  appGroupId: '634d62e10ef4e37a75846f41',
 });


### PR DESCRIPTION
- Sets the `braze_ext_id` and `braze_int_id` cookies if the relevant query parameter is found
- Redirects to remove the params, if they were present (prevent context change by sharing via FB, etc)
- Updates GAMTracker integration to send the braze IDs if present

Currently does _not_ set the external user id to IdentityX or look up an IdentityX user if they are not logged in.