### PR TITLE
Gated content and Braze soft-login support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,6 +84,7 @@ services:
       LIVERELOAD_PORT: 19951
       SITE_ID: 63038dcdd15c7c4b2e8b4588
       AUTH0_BASEURL: http://www-smg-sab.dev.parameter1.com:9951
+      AUTH0_ISSUER_BASEURL: ${AUTH0_ISSUER_BASEURL_SAB-}
       BRAZE_API_KEY: ${BRAZE_API_KEY_SAB}
       AUTH0_SECRET: ${AUTH0_CLIENT_SECRET_SAB}
     hostname: www-smg-sab.dev.parameter1.com
@@ -102,6 +103,7 @@ services:
       LIVERELOAD_PORT: 19952
       SITE_ID: 62fc0ab6475dbd28008b459b
       AUTH0_BASEURL: http://www-smg-lab.dev.parameter1.com:9952
+      AUTH0_ISSUER_BASEURL: ${AUTH0_ISSUER_BASEURL_LAB-}
       BRAZE_API_KEY: ${BRAZE_API_KEY_LAB}
       AUTH0_SECRET: ${AUTH0_CLIENT_SECRET_LAB}
     hostname: www-smg-lab.dev.parameter1.com
@@ -120,6 +122,7 @@ services:
       LIVERELOAD_PORT: 19953
       SITE_ID: 63038e29475dbd6a2f8b457e
       AUTH0_BASEURL: http://www-smg-drb.dev.parameter1.com:9953
+      AUTH0_ISSUER_BASEURL: ${AUTH0_ISSUER_BASEURL_DRB-}
       BRAZE_API_KEY: ${BRAZE_API_KEY_DRB}
       AUTH0_SECRET: ${AUTH0_CLIENT_SECRET_DRB}
     hostname: www-smg-drb.dev.parameter1.com
@@ -138,6 +141,7 @@ services:
       LIVERELOAD_PORT: 19954
       SITE_ID: 63038e5dd15c7c4b2e8b458a
       AUTH0_BASEURL: http://www-smg-am.dev.parameter1.com:9954
+      AUTH0_ISSUER_BASEURL: ${AUTH0_ISSUER_BASEURL_AM-}
       BRAZE_API_KEY: ${BRAZE_API_KEY_AM}
       AUTH0_SECRET: ${AUTH0_CLIENT_SECRET_AM}
     hostname: www-smg-am.dev.parameter1.com
@@ -156,6 +160,7 @@ services:
       LIVERELOAD_PORT: 19955
       SITE_ID: 63038e96d15c7cc42e8b4581
       AUTH0_BASEURL: http://www-smg-ame.dev.parameter1.com:9955
+      AUTH0_ISSUER_BASEURL: ${AUTH0_ISSUER_BASEURL_AM-}
       BRAZE_API_KEY: ${BRAZE_API_KEY_AM}
       AUTH0_SECRET: ${AUTH0_CLIENT_SECRET_AM}
     hostname: www-smg-ame.dev.parameter1.com
@@ -174,6 +179,7 @@ services:
       LIVERELOAD_PORT: 19956
       SITE_ID: 63038ec219398c102f8b457c
       AUTH0_BASEURL: http://www-smg-ama.dev.parameter1.com:9956
+      AUTH0_ISSUER_BASEURL: ${AUTH0_ISSUER_BASEURL_AM-}
       BRAZE_API_KEY: ${BRAZE_API_KEY_AM}
       AUTH0_SECRET: ${AUTH0_CLIENT_SECRET_AM}
     hostname: www-smg-ama.dev.parameter1.com

--- a/packages/braze/graphql/queries/find-user-by-id.js
+++ b/packages/braze/graphql/queries/find-user-by-id.js
@@ -1,0 +1,29 @@
+const gql = require('graphql-tag');
+
+module.exports = gql`
+query FindAppUserFromBrazeId($input: AppUserByIdQueryInput!) {
+  appUserById(input: $input) {
+    id
+    email
+    # Additional required fields
+    givenName
+    familyName
+    organization
+    city
+    regionCode
+    countryCode
+    # Custom boolean fields
+    customBooleanFieldAnswers(input: { onlyActive: true }) {
+      id
+      field { required }
+      hasAnswered
+    }
+    # Custom select fields
+    customSelectFieldAnswers(input: { onlyActive: true }) {
+      id
+      field { required }
+      hasAnswered
+    }
+  }
+}
+`;

--- a/packages/braze/middleware/set-identity-cookie.js
+++ b/packages/braze/middleware/set-identity-cookie.js
@@ -1,0 +1,79 @@
+const { asyncRoute } = require('@parameter1/base-cms-utils');
+const { getAsArray } = require('@parameter1/base-cms-object-path');
+const debug = require('debug')('gating');
+const findAppUserById = require('../graphql/queries/find-user-by-id');
+
+const COOKIE_NAME = '__idx_gating';
+const COOKIE_MAXAGE = 7 * 24 * 60 * 60;
+
+const getCookie = ({ req, res, name }) => {
+  const parse = (cookies = []) => {
+    try {
+      return cookies.reduce((obj, cookie) => {
+        const [key, value] = `${cookie};`.split(';')[0].split('=');
+        return { ...obj, [key]: value };
+      }, {});
+    } catch (e) {
+      // noop
+    }
+    return {};
+  };
+
+  const parsed = parse(res.get('set-cookie'));
+  if (parsed[name]) return parsed[name];
+
+  const { cookies } = req;
+  return cookies[name];
+};
+
+const findUserBy = async ({ idx, id }) => {
+  const { client, config } = idx;
+  const apiToken = config.getApiToken();
+  if (!apiToken) throw new Error('Unable to look up user: No API token has been configured.');
+  const { data } = await client.query({
+    query: findAppUserById,
+    variables: { input: { id } },
+    context: { apiToken },
+  });
+  return data.appUserById;
+};
+
+const hasAllRequiredFields = ({ idx, user }) => {
+  const requiredFields = idx.config.getRequiredServerFields();
+  const hasRequiredFields = requiredFields.every(f => user[f]);
+  if (!hasRequiredFields) return false;
+
+  // Check booleans
+  const hasAllBools = getAsArray(user, 'customBooleanFieldAnswers').every(a => !a.field.required || a.hasAnswered);
+  if (!hasAllBools) return false;
+
+  // Check selects
+  const hasAllSelects = getAsArray(user, 'customSelectFieldAnswers').every(a => !a.field.required || a.hasAnswered);
+  if (!hasAllSelects) return false;
+
+  return true;
+};
+
+/**
+ * Sets the `__idx_gating` cookie based on incoming identity data
+ */
+module.exports = asyncRoute(async (req, res, next) => {
+  // Don't do anything if a user is logged in.
+  if (req.identityX && req.identityX.token) return next();
+
+  // If we have Braze IDs, attempt to find and check the IdentityX user.
+  const brazeExtId = getCookie({ req, res, name: 'braze_ext_id' });
+  debug({ brazeExtId });
+  if (!brazeExtId) return next();
+
+  // Find the user in IdentityX.
+  const user = await findUserBy({ idx: req.identityX, id: brazeExtId });
+  if (!user) return next();
+
+  const canAccess = hasAllRequiredFields({ idx: req.identityX, user });
+  debug({ hasAllRequiredFields: canAccess });
+  if (!res.headersSent) {
+    res.cookie(COOKIE_NAME, JSON.stringify(canAccess), { maxAge: COOKIE_MAXAGE });
+  }
+  return next();
+});

--- a/packages/braze/middleware/set-identity-cookie.js
+++ b/packages/braze/middleware/set-identity-cookie.js
@@ -67,7 +67,7 @@ module.exports = asyncRoute(async (req, res, next) => {
   // If we have Braze IDs, attempt to find and check the IdentityX user.
   const brazeExtId = getCookie({ req, res, name: 'braze_ext_id' });
   debug({ brazeExtId });
-  if (!brazeExtId || !/^[a-z0-f]{24}$/g.test(brazeExtId)) return next();
+  if (!brazeExtId || !/^[a-z0-f]{24}$/i.test(brazeExtId)) return next();
 
   // Find the user in IdentityX.
   const user = await findUserBy({ idx: req.identityX, id: brazeExtId });

--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -2,7 +2,13 @@ import { getAsArray, get } from "@parameter1/base-cms-object-path";
 import contentIframe from "@science-medicine-group/package-global/utils/content-iframe";
 import getContentPreview from "@parameter1/base-cms-marko-web-theme-monorail/utils/get-content-preview";
 
-$ const { site, contentMeterState } = out.global;
+$ const {
+  contentGatingHandler,
+  contentMeterState,
+  req,
+  res,
+  site,
+} = out.global;
 
 $ const { id, type, pageNode, showReadNextBlock, showBottomAdBlock, showTopStoryBlock, ...rest } = input;
 $ const sections = getAsArray(input, "sections");
@@ -79,8 +85,11 @@ $ const shouldInjectAds = ["article", "video", "news", "podcast"].includes(type)
               </marko-web-link>
             </if>
 
-            $ const requiresRegistration = get(content, "userRegistration.isCurrentlyRequired");
-            <marko-web-identity-x-access|context| enabled=requiresRegistration>
+            $ const [enabled, accessLevels] = contentGatingHandler({ content, req, res });
+            <marko-web-identity-x-access|context|
+              enabled=enabled
+              required-access-level-ids=accessLevels
+            >
               <if(!context.canAccess || context.requiresUserInput)>
                 $ const body = getContentPreview({ body: content.body, selector: "p:nth-of-type(1)" });
                 <marko-web-content-body block-name=blockName obj={ body } />

--- a/packages/global/middleware/content-gating.js
+++ b/packages/global/middleware/content-gating.js
@@ -13,7 +13,7 @@ const COOKIE_NAME = '__idx_gating';
  *
  * @returns Promise([Boolean, String[]])
  */
-module.exports = app => contentGating(app, true, async ({ content, req, res }) => {
+module.exports = app => contentGating(app, true, ({ content, req, res }) => {
   const { identityX } = req;
   const requiresRegistration = get(content, 'userRegistration.isCurrentlyRequired');
   const accessLevels = getAsArray(content, 'userRegistration.accessLevels');

--- a/packages/global/middleware/content-gating.js
+++ b/packages/global/middleware/content-gating.js
@@ -1,0 +1,41 @@
+const { get, getAsArray } = require('@parameter1/base-cms-object-path');
+const contentGating = require('@parameter1/base-cms-marko-web-theme-monorail/middleware/content-gating');
+const getCookie = require('../utils/get-cookie');
+
+const COOKIE_NAME = '__idx_gating';
+
+/**
+ * Returns a tuple of the enabled/disabled state and required access level ids
+ *
+ * @param content Object
+ * @param req Object
+ * @param res Object
+ *
+ * @returns Promise([Boolean, String[]])
+ */
+module.exports = app => contentGating(app, true, async ({ content, req, res }) => {
+  const { identityX } = req;
+  const requiresRegistration = get(content, 'userRegistration.isCurrentlyRequired');
+  const accessLevels = getAsArray(content, 'userRegistration.accessLevels');
+
+  // If the content isn't gated, do nothing.
+  if (!requiresRegistration) return [requiresRegistration, accessLevels];
+
+  // If a user is logged in, enable and don't do anything special.
+  if (identityX && identityX.token) return [requiresRegistration, accessLevels];
+
+  // Check for `__idx_gating` cookie, set by Braze Identity middleware
+  const cookie = getCookie({ req, res, name: COOKIE_NAME });
+
+  if (cookie) {
+    try {
+      const allowed = JSON.parse(cookie);
+      return [!allowed, accessLevels];
+    } catch (e) {
+      // noop
+    }
+  }
+
+  // Final fallback
+  return [requiresRegistration, accessLevels];
+});

--- a/packages/global/middleware/newsletter-state.js
+++ b/packages/global/middleware/newsletter-state.js
@@ -5,9 +5,9 @@ const newsletterState = ({ setCookie = true } = {}) => (req, res, next) => {
   const hasCookie = Boolean(get(req, `cookies.${cookieName}`));
   const hasUser = Boolean(get(req, 'cookies.__idx'));
   const utmMedium = get(req, 'query.utm_medium');
-  const olyEncId = get(req, 'query.oly_enc_id');
+  const brazeExtId = get(req, 'query.braze_ext_id');
   const disabled = get(req, 'query.newsletterDisabled');
-  const fromEmail = utmMedium === 'email' || olyEncId || false;
+  const fromEmail = utmMedium === 'email' || brazeExtId || false;
   const canBeInitiallyExpanded = !(hasCookie || fromEmail || hasUser || disabled);
   const initiallyExpanded = (setCookie === true) && canBeInitiallyExpanded;
 

--- a/packages/global/start-server.js
+++ b/packages/global/start-server.js
@@ -15,6 +15,7 @@ const components = require('./components');
 const fragments = require('./fragments');
 const idxRouteTemplates = require('./templates/user');
 const sharedRoutes = require('./routes');
+const contentGating = require('./middleware/content-gating');
 const paginated = require('./middleware/paginated');
 const gamTracker = require('./middleware/gam-tracker');
 const oembedHandler = require('./oembed-handler');
@@ -85,6 +86,9 @@ module.exports = (options = {}) => {
       // i18n
       const i18n = v => v;
       set(app.locals, 'i18n', options.i18n || i18n);
+
+      // Install custom content gating middleware
+      contentGating(app);
 
       // Must always be loaded last!
       app.use(gamTracker);

--- a/packages/global/utils/get-cookie.js
+++ b/packages/global/utils/get-cookie.js
@@ -1,0 +1,22 @@
+const parse = (cookies = []) => {
+  try {
+    return cookies.reduce((obj, cookie) => {
+      const [key, value] = `${cookie};`.split(';')[0].split('=');
+      return { ...obj, [key]: value };
+    }, {});
+  } catch (e) {
+    // noop
+  }
+  return {};
+};
+
+/**
+ * Retrieves a cookie by name from the response (first) or request (second)
+ */
+module.exports = ({ req, res, name }) => {
+  const parsed = parse(res.get('set-cookie'));
+  if (parsed[name]) return parsed[name];
+
+  const { cookies } = req;
+  return cookies[name];
+};

--- a/sites/auntminnie.com/package.json
+++ b/sites/auntminnie.com/package.json
@@ -23,6 +23,7 @@
     "@parameter1/base-cms-object-path": "^3.0.0",
     "@parameter1/base-cms-utils": "^3.0.0",
     "@parameter1/base-cms-web-cli": "^3.14.0",
+    "@science-medicine-group/package-braze": "^1.7.5",
     "@science-medicine-group/package-global": "^1.7.5",
     "csvtojson": "^2.0.10",
     "debounce": "^1.2.0",

--- a/sites/auntminnie.com/server/routes/content.js
+++ b/sites/auntminnie.com/server/routes/content.js
@@ -1,4 +1,6 @@
 const withContent = require('@science-medicine-group/package-global/middleware/with-content');
+const { newsletterState, formatContentResponse } = require('@science-medicine-group/package-global/middleware/newsletter-state');
+const setBrazeIdentityCookie = require('@science-medicine-group/package-braze/middleware/set-identity-cookie');
 const queryFragment = require('@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/content-page');
 const contact = require('@science-medicine-group/package-global/templates/content/contact');
 const company = require('../templates/content/company');
@@ -7,28 +9,33 @@ const whitepaper = require('../templates/content/whitepaper');
 const content = require('../templates/content');
 
 module.exports = (app) => {
-  app.get('/*?contact/:id(\\d{8})*', withContent({
+  app.get('/*?contact/:id(\\d{8})*', newsletterState({ setCookie: false }), newsletterState({ setCookie: false }), withContent({
     template: contact,
     queryFragment,
+    formatResponse: formatContentResponse,
   }));
 
-  app.get('/*?company/:id(\\d{8})*', withContent({
+  app.get('/*?company/:id(\\d{8})*', newsletterState({ setCookie: false }), withContent({
     template: company,
     queryFragment,
+    formatResponse: formatContentResponse,
   }));
 
-  app.get('/*?product/:id(\\d{8})*', withContent({
+  app.get('/*?product/:id(\\d{8})*', newsletterState({ setCookie: false }), withContent({
     template: product,
     queryFragment,
+    formatResponse: formatContentResponse,
   }));
 
-  app.get('/*?whitepaper/:id(\\d{8})*', withContent({
+  app.get('/*?whitepaper/:id(\\d{8})*', newsletterState({ setCookie: false }), withContent({
     template: whitepaper,
     queryFragment,
+    formatResponse: formatContentResponse,
   }));
 
-  app.get('/*?/:id(\\d{8})/*|/:id(\\d{8})(/|$)', withContent({
+  app.get('/*?/:id(\\d{8})/*|/:id(\\d{8})(/|$)', newsletterState({ setCookie: false }), setBrazeIdentityCookie, withContent({
     template: content,
     queryFragment,
+    formatResponse: formatContentResponse,
   }));
 };

--- a/sites/auntminnieasia.com/package.json
+++ b/sites/auntminnieasia.com/package.json
@@ -23,6 +23,7 @@
     "@parameter1/base-cms-object-path": "^3.0.0",
     "@parameter1/base-cms-utils": "^3.0.0",
     "@parameter1/base-cms-web-cli": "^3.14.0",
+    "@science-medicine-group/package-braze": "^1.7.5",
     "@science-medicine-group/package-global": "^1.7.5",
     "csvtojson": "^2.0.10",
     "debounce": "^1.2.0",

--- a/sites/auntminnieasia.com/server/routes/content.js
+++ b/sites/auntminnieasia.com/server/routes/content.js
@@ -1,4 +1,6 @@
 const withContent = require('@science-medicine-group/package-global/middleware/with-content');
+const { newsletterState, formatContentResponse } = require('@science-medicine-group/package-global/middleware/newsletter-state');
+const setBrazeIdentityCookie = require('@science-medicine-group/package-braze/middleware/set-identity-cookie');
 const queryFragment = require('@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/content-page');
 const contact = require('@science-medicine-group/package-global/templates/content/contact');
 const company = require('../templates/content/company');
@@ -7,28 +9,33 @@ const whitepaper = require('../templates/content/whitepaper');
 const content = require('../templates/content');
 
 module.exports = (app) => {
-  app.get('/*?contact/:id(\\d{8})*', withContent({
+  app.get('/*?contact/:id(\\d{8})*', newsletterState({ setCookie: false }), newsletterState({ setCookie: false }), withContent({
     template: contact,
     queryFragment,
+    formatResponse: formatContentResponse,
   }));
 
-  app.get('/*?company/:id(\\d{8})*', withContent({
+  app.get('/*?company/:id(\\d{8})*', newsletterState({ setCookie: false }), withContent({
     template: company,
     queryFragment,
+    formatResponse: formatContentResponse,
   }));
 
-  app.get('/*?product/:id(\\d{8})*', withContent({
+  app.get('/*?product/:id(\\d{8})*', newsletterState({ setCookie: false }), withContent({
     template: product,
     queryFragment,
+    formatResponse: formatContentResponse,
   }));
 
-  app.get('/*?whitepaper/:id(\\d{8})*', withContent({
+  app.get('/*?whitepaper/:id(\\d{8})*', newsletterState({ setCookie: false }), withContent({
     template: whitepaper,
     queryFragment,
+    formatResponse: formatContentResponse,
   }));
 
-  app.get('/*?/:id(\\d{8})/*|/:id(\\d{8})(/|$)', withContent({
+  app.get('/*?/:id(\\d{8})/*|/:id(\\d{8})(/|$)', newsletterState({ setCookie: false }), setBrazeIdentityCookie, withContent({
     template: content,
     queryFragment,
+    formatResponse: formatContentResponse,
   }));
 };

--- a/sites/auntminnieeurope.com/package.json
+++ b/sites/auntminnieeurope.com/package.json
@@ -23,6 +23,7 @@
     "@parameter1/base-cms-object-path": "^3.0.0",
     "@parameter1/base-cms-utils": "^3.0.0",
     "@parameter1/base-cms-web-cli": "^3.14.0",
+    "@science-medicine-group/package-braze": "^1.7.5",
     "@science-medicine-group/package-global": "^1.7.5",
     "csvtojson": "^2.0.10",
     "debounce": "^1.2.0",

--- a/sites/auntminnieeurope.com/server/routes/content.js
+++ b/sites/auntminnieeurope.com/server/routes/content.js
@@ -1,4 +1,6 @@
 const withContent = require('@science-medicine-group/package-global/middleware/with-content');
+const { newsletterState, formatContentResponse } = require('@science-medicine-group/package-global/middleware/newsletter-state');
+const setBrazeIdentityCookie = require('@science-medicine-group/package-braze/middleware/set-identity-cookie');
 const queryFragment = require('@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/content-page');
 const contact = require('@science-medicine-group/package-global/templates/content/contact');
 const company = require('../templates/content/company');
@@ -7,28 +9,33 @@ const whitepaper = require('../templates/content/whitepaper');
 const content = require('../templates/content');
 
 module.exports = (app) => {
-  app.get('/*?contact/:id(\\d{8})*', withContent({
+  app.get('/*?contact/:id(\\d{8})*', newsletterState({ setCookie: false }), newsletterState({ setCookie: false }), withContent({
     template: contact,
     queryFragment,
+    formatResponse: formatContentResponse,
   }));
 
-  app.get('/*?company/:id(\\d{8})*', withContent({
+  app.get('/*?company/:id(\\d{8})*', newsletterState({ setCookie: false }), withContent({
     template: company,
     queryFragment,
+    formatResponse: formatContentResponse,
   }));
 
-  app.get('/*?product/:id(\\d{8})*', withContent({
+  app.get('/*?product/:id(\\d{8})*', newsletterState({ setCookie: false }), withContent({
     template: product,
     queryFragment,
+    formatResponse: formatContentResponse,
   }));
 
-  app.get('/*?whitepaper/:id(\\d{8})*', withContent({
+  app.get('/*?whitepaper/:id(\\d{8})*', newsletterState({ setCookie: false }), withContent({
     template: whitepaper,
     queryFragment,
+    formatResponse: formatContentResponse,
   }));
 
-  app.get('/*?/:id(\\d{8})/*|/:id(\\d{8})(/|$)', withContent({
+  app.get('/*?/:id(\\d{8})/*|/:id(\\d{8})(/|$)', newsletterState({ setCookie: false }), setBrazeIdentityCookie, withContent({
     template: content,
     queryFragment,
+    formatResponse: formatContentResponse,
   }));
 };

--- a/sites/drbicuspid.com/package.json
+++ b/sites/drbicuspid.com/package.json
@@ -23,6 +23,7 @@
     "@parameter1/base-cms-object-path": "^3.0.0",
     "@parameter1/base-cms-utils": "^3.0.0",
     "@parameter1/base-cms-web-cli": "^3.14.0",
+    "@science-medicine-group/package-braze": "^1.7.5",
     "@science-medicine-group/package-global": "^1.7.5",
     "csvtojson": "^2.0.10",
     "debounce": "^1.2.0",

--- a/sites/drbicuspid.com/server/routes/content.js
+++ b/sites/drbicuspid.com/server/routes/content.js
@@ -1,4 +1,6 @@
 const withContent = require('@science-medicine-group/package-global/middleware/with-content');
+const { newsletterState, formatContentResponse } = require('@science-medicine-group/package-global/middleware/newsletter-state');
+const setBrazeIdentityCookie = require('@science-medicine-group/package-braze/middleware/set-identity-cookie');
 const queryFragment = require('@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/content-page');
 const contact = require('@science-medicine-group/package-global/templates/content/contact');
 const company = require('../templates/content/company');
@@ -7,28 +9,33 @@ const whitepaper = require('../templates/content/whitepaper');
 const content = require('../templates/content');
 
 module.exports = (app) => {
-  app.get('/*?contact/:id(\\d{8})*', withContent({
+  app.get('/*?contact/:id(\\d{8})*', newsletterState({ setCookie: false }), newsletterState({ setCookie: false }), withContent({
     template: contact,
     queryFragment,
+    formatResponse: formatContentResponse,
   }));
 
-  app.get('/*?company/:id(\\d{8})*', withContent({
+  app.get('/*?company/:id(\\d{8})*', newsletterState({ setCookie: false }), withContent({
     template: company,
     queryFragment,
+    formatResponse: formatContentResponse,
   }));
 
-  app.get('/*?product/:id(\\d{8})*', withContent({
+  app.get('/*?product/:id(\\d{8})*', newsletterState({ setCookie: false }), withContent({
     template: product,
     queryFragment,
+    formatResponse: formatContentResponse,
   }));
 
-  app.get('/*?whitepaper/:id(\\d{8})*', withContent({
+  app.get('/*?whitepaper/:id(\\d{8})*', newsletterState({ setCookie: false }), withContent({
     template: whitepaper,
     queryFragment,
+    formatResponse: formatContentResponse,
   }));
 
-  app.get('/*?/:id(\\d{8})/*|/:id(\\d{8})(/|$)', withContent({
+  app.get('/*?/:id(\\d{8})/*|/:id(\\d{8})(/|$)', newsletterState({ setCookie: false }), setBrazeIdentityCookie, withContent({
     template: content,
     queryFragment,
+    formatResponse: formatContentResponse,
   }));
 };

--- a/sites/labpulse.com/package.json
+++ b/sites/labpulse.com/package.json
@@ -23,6 +23,7 @@
     "@parameter1/base-cms-object-path": "^3.0.0",
     "@parameter1/base-cms-utils": "^3.0.0",
     "@parameter1/base-cms-web-cli": "^3.14.0",
+    "@science-medicine-group/package-braze": "^1.7.5",
     "@science-medicine-group/package-global": "^1.7.5",
     "csvtojson": "^2.0.10",
     "debounce": "^1.2.0",

--- a/sites/labpulse.com/server/routes/content.js
+++ b/sites/labpulse.com/server/routes/content.js
@@ -1,5 +1,6 @@
 const withContent = require('@science-medicine-group/package-global/middleware/with-content');
 const { newsletterState, formatContentResponse } = require('@science-medicine-group/package-global/middleware/newsletter-state');
+const setBrazeIdentityCookie = require('@science-medicine-group/package-braze/middleware/set-identity-cookie');
 const queryFragment = require('@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/content-page');
 const contact = require('@science-medicine-group/package-global/templates/content/contact');
 const company = require('../templates/content/company');
@@ -32,7 +33,7 @@ module.exports = (app) => {
     formatResponse: formatContentResponse,
   }));
 
-  app.get('/*?/:id(\\d{8})/*|/:id(\\d{8})(/|$)', newsletterState({ setCookie: false }), withContent({
+  app.get('/*?/:id(\\d{8})/*|/:id(\\d{8})(/|$)', newsletterState({ setCookie: false }), setBrazeIdentityCookie, withContent({
     template: content,
     queryFragment,
     formatResponse: formatContentResponse,

--- a/sites/scienceboard.net/package.json
+++ b/sites/scienceboard.net/package.json
@@ -23,6 +23,7 @@
     "@parameter1/base-cms-object-path": "^3.0.0",
     "@parameter1/base-cms-utils": "^3.0.0",
     "@parameter1/base-cms-web-cli": "^3.14.0",
+    "@science-medicine-group/package-braze": "^1.7.5",
     "@science-medicine-group/package-global": "^1.7.5",
     "csvtojson": "^2.0.10",
     "debounce": "^1.2.0",

--- a/sites/scienceboard.net/server/routes/content.js
+++ b/sites/scienceboard.net/server/routes/content.js
@@ -1,4 +1,6 @@
 const withContent = require('@science-medicine-group/package-global/middleware/with-content');
+const { newsletterState, formatContentResponse } = require('@science-medicine-group/package-global/middleware/newsletter-state');
+const setBrazeIdentityCookie = require('@science-medicine-group/package-braze/middleware/set-identity-cookie');
 const queryFragment = require('@parameter1/base-cms-marko-web-theme-monorail/graphql/fragments/content-page');
 const contact = require('@science-medicine-group/package-global/templates/content/contact');
 const company = require('../templates/content/company');
@@ -7,28 +9,33 @@ const whitepaper = require('../templates/content/whitepaper');
 const content = require('../templates/content');
 
 module.exports = (app) => {
-  app.get('/*?contact/:id(\\d{8})*', withContent({
+  app.get('/*?contact/:id(\\d{8})*', newsletterState({ setCookie: false }), newsletterState({ setCookie: false }), withContent({
     template: contact,
     queryFragment,
+    formatResponse: formatContentResponse,
   }));
 
-  app.get('/*?company/:id(\\d{8})*', withContent({
+  app.get('/*?company/:id(\\d{8})*', newsletterState({ setCookie: false }), withContent({
     template: company,
     queryFragment,
+    formatResponse: formatContentResponse,
   }));
 
-  app.get('/*?product/:id(\\d{8})*', withContent({
+  app.get('/*?product/:id(\\d{8})*', newsletterState({ setCookie: false }), withContent({
     template: product,
     queryFragment,
+    formatResponse: formatContentResponse,
   }));
 
-  app.get('/*?whitepaper/:id(\\d{8})*', withContent({
+  app.get('/*?whitepaper/:id(\\d{8})*', newsletterState({ setCookie: false }), withContent({
     template: whitepaper,
     queryFragment,
+    formatResponse: formatContentResponse,
   }));
 
-  app.get('/*?/:id(\\d{8})/*|/:id(\\d{8})(/|$)', withContent({
+  app.get('/*?/:id(\\d{8})/*|/:id(\\d{8})(/|$)', newsletterState({ setCookie: false }), setBrazeIdentityCookie, withContent({
     template: content,
     queryFragment,
+    formatResponse: formatContentResponse,
   }));
 };


### PR DESCRIPTION
Requires parameter1/identity-x#24

- Adds content gating middleware to read the `__idx_gating` cookie to read previously computed identity state.
- Adds braze identity middleware to set the `__idx_gating` cookie (currently with 7d duration)
  - Enabled on the content route for each site
  - Unify newsletterState/formatting in site content routes