### PR TITLE
update newsletter-signup component with hasUser logic

### DIFF
--- a/packages/global/components/newsletter-signup.marko
+++ b/packages/global/components/newsletter-signup.marko
@@ -1,6 +1,7 @@
 $ const { name, description, modifiers } = input;
 $ const href = input.href || "/login";
 $ const cta = input.cta || "Sign Up";
+$ const hasUser = input.hasUser;
 
 <marko-web-block name="newsletter-signup-banner" modifiers=modifiers>
   <marko-web-element block-name="newsletter-signup-banner" name="name" modifiers=modifiers>
@@ -10,8 +11,18 @@ $ const cta = input.cta || "Sign Up";
     ${description}
   </marko-web-element>
   <marko-web-element block-name="newsletter-signup-banner" name="cta" modifiers=modifiers>
-    <a href=href class="btn btn-primary">
-      ${cta}
-    </a>
+    <if(!hasUser)>
+      <a href=href class="btn btn-primary">
+        ${cta}
+      </a>
+    </if>
+    <else>
+      <a href="/user/profile" class="btn btn-secondary">
+        Manage Profile
+      </a>
+      <a href="/logout" class="btn btn-primary">
+        Sign Out
+      </a>
+    </else>
   </marko-web-element>
 </marko-web-block>

--- a/packages/global/components/site-footer.marko
+++ b/packages/global/components/site-footer.marko
@@ -65,12 +65,11 @@ $ const tagline = site.get("tagline");
         <if(newsletterConfig.enable)>
           <div class=`col-md-${newsletterConfig.colspan || 4} mb-block`>
             <marko-web-identity-x-context|{ hasUser }|>
-              $ const href = (hasUser) ? "/user/profile" : "/login";
               <global-newsletter-signup
                 name=newsletterConfig.name
                 description=newsletterConfig.description
                 modifiers=["footer"]
-                href=href
+                hasUser=hasUser
               />
             </marko-web-identity-x-context>
           </div>

--- a/packages/global/scss/components/_site-footer.scss
+++ b/packages/global/scss/components/_site-footer.scss
@@ -44,4 +44,15 @@
       }
     }
   }
+  .newsletter-signup-banner {
+    .btn {
+      margin-bottom: map-get($spacers, 2);
+    }
+    .btn-secondary,
+    .btn-secondary:hover,
+    .btn-secondary:focus {
+      background-color: $white;
+      margin-right: map-get($spacers, 2);
+    }
+  }
 }


### PR DESCRIPTION
Add hasUser Logic to the newsletter-signup component in order to display Manage Profile & Sign Out buttons when a user is present vs always showing Sign Up.

The only other place this component is being used it is wrapped in a !hasUser Check within section content.


<img width="1089" alt="Screen Shot 2022-12-21 at 10 02 15 AM" src="https://user-images.githubusercontent.com/3845869/208949416-e8632827-338d-4b63-b752-e0c488d81362.png">
<img width="382" alt="Screen Shot 2022-12-21 at 10 02 25 AM" src="https://user-images.githubusercontent.com/3845869/208949427-1ec1a272-d214-4780-a04b-85b9e7001ce0.png">
<img width="822" alt="Screen Shot 2022-12-21 at 10 02 41 AM" src="https://user-images.githubusercontent.com/3845869/208949433-d5e4bcc9-157c-4ab4-aff9-4ec4e06b27dc.png">
