### PR TITLE
STAGING: Fix alias base ad injections & content meter placement & styling for bottom leaderboard 

### DIFF
--- a/packages/global/components/document.marko
+++ b/packages/global/components/document.marko
@@ -93,6 +93,8 @@ $ const { gamDefer, gtmDefer, initOnly } = req.query;
     <marko-web-identity-x-context|{ hasUser, isEnabled }|>
       <global-site-footer  has-user=hasUser reg-enabled=isEnabled />
     </marko-web-identity-x-context>
+  </@below-container>
+  <@below-wrapper>
     <if(contentMeterState && !contentMeterState.isLoggedIn)>
       <global-content-meter-block
         views=contentMeterState.views
@@ -101,8 +103,6 @@ $ const { gamDefer, gtmDefer, initOnly } = req.query;
         display-gate=contentMeterState.displayGate
       />
     </if>
-  </@below-container>
-  <@below-wrapper>
     <marko-web-deferred-script-loader-load />
   </@below-wrapper>
 </marko-web-document>

--- a/packages/global/components/wrappers/components/section-feed-block.marko
+++ b/packages/global/components/wrappers/components/section-feed-block.marko
@@ -1,3 +1,5 @@
+$ const aliases = input.aliases || [input.alias];
+
 <theme-section-feed-block
   alias=input.alias
   header=input.header
@@ -10,7 +12,7 @@
       <theme-gam-define-display-ad
         name="rotation"
         position="section_page"
-        aliases=input.aliases
+        aliases=aliases
         modifiers=["inline-section-feed"]
       />
     </@after>

--- a/packages/global/components/wrappers/section-feed.marko
+++ b/packages/global/components/wrappers/section-feed.marko
@@ -1,9 +1,11 @@
 import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
+import { getAsArray } from "@parameter1/base-cms-object-path";
 
 $ const { pagination: p } = out.global;
 $ const perPage = 12;
 $ const withPagination = defaultValue(input.withPagination, true);
 $ const { modifiers } = input;
+$ const aliases = getAsArray(input, 'aliases');
 $ const withAds = defaultValue(input.withAds, true);
 $ const queryParams = {
   requiresImage: false,
@@ -22,6 +24,7 @@ $ const queryParams = {
         skip=p.skip({ perPage })
         node-list=input.nodeList
         with-ads=withAds
+        aliases=aliases
       />
       <section-feed-block
         alias=input.alias
@@ -31,6 +34,7 @@ $ const queryParams = {
         skip=p.skip({ perPage, skip: 3 })
         node-list=input.nodeList
         with-ads=withAds
+        aliases=aliases
       />
       <section-feed-block
         alias=input.alias
@@ -41,6 +45,7 @@ $ const queryParams = {
         skip=p.skip({ perPage, skip: 6 })
         node-list=input.nodeList
         with-ads=withAds
+        aliases=aliases
       />
       <section-feed-block
         alias=input.alias
@@ -49,6 +54,7 @@ $ const queryParams = {
         limit=3
         skip=p.skip({ perPage, skip: 9 })
         node-list=input.nodeList
+        aliases=aliases
       />
       <if(withPagination)>
         <theme-section-feed-block|{ totalCount }| alias=input.alias count-only=true>
@@ -78,6 +84,7 @@ $ const queryParams = {
         skip=p.skip({ perPage })
         node-list=input.nodeList
         with-ads=withAds
+        aliases=aliases
       />
       <section-feed-block
         alias=input.alias
@@ -87,6 +94,7 @@ $ const queryParams = {
         skip=p.skip({ perPage, skip: 3 })
         node-list=input.nodeList
         with-ads=withAds
+        aliases=aliases
       />
     </div>
     <div class="col-lg-4">
@@ -109,6 +117,7 @@ $ const queryParams = {
         skip=p.skip({ perPage, skip: 6 })
         node-list=input.nodeList
         with-ads=withAds
+        aliases=aliases
       />
       <section-feed-block
         alias=input.alias
@@ -117,6 +126,7 @@ $ const queryParams = {
         limit=3
         skip=p.skip({ perPage, skip: 9 })
         node-list=input.nodeList
+        aliases=aliases
       />
       <if(withPagination)>
         <theme-section-feed-block|{ totalCount }| alias=input.alias count-only=true>

--- a/packages/global/scss/components/content-meter.scss
+++ b/packages/global/scss/components/content-meter.scss
@@ -1,19 +1,6 @@
 $content-meter-mobile-breakpoint: 600px !default;
 .content-meter {
   $self: &;
-  ~ .site-footer {
-    margin-bottom: 72px;
-  }
-  &--display-overlay {
-    ~ .site-footer {
-      display: none;
-      margin-bottom: 0;
-    }
-    ~ .document-container {
-      height: 0;
-      overflow: hidden;
-    }
-  }
   &__overlay {
     z-index: 1499;
     position: fixed;
@@ -110,12 +97,6 @@ $content-meter-mobile-breakpoint: 600px !default;
   }
 
   &--open {
-    ~ .site-footer {
-      margin-bottom: 296px;
-      @media (min-width: $content-meter-mobile-breakpoint) {
-        margin-bottom: 166px;
-      }
-    }
     #{ $self } {
       &__bar {
         padding-bottom: map-get($spacers, 4);
@@ -137,6 +118,15 @@ $content-meter-mobile-breakpoint: 600px !default;
           min-height: 48px;
         }
       }
+    }
+  }
+}
+
+.marko-web-gam-fixed-ad-bottom--visible ~ .content-meter {
+  .content-meter__bar{
+    padding-bottom: 120px;
+    @media (max-width: $content-meter-mobile-breakpoint) {
+      padding-bottom: 70px;
     }
   }
 }


### PR DESCRIPTION
Ensure that aliases is being passed through correctly to the section feeds block. Also pulled in the ssr injection change for https://github.com/parameter1/base-cms/pull/530 so that the content body ads display the primary section's ads if available.
<img width="1135" alt="Screen Shot 2023-01-04 at 1 47 24 PM" src="https://user-images.githubusercontent.com/3845869/210645036-83bc7ac5-be39-40d2-8629-c8a36d39b78d.png">
<img width="1135" alt="Screen Shot 2023-01-04 at 1 47 35 PM" src="https://user-images.githubusercontent.com/3845869/210645044-be1618df-00cc-4da6-9b05-66ac365e1252.png">

