### PR TITLE
Fix spelling ‘Website’

### DIFF
--- a/packages/global/components/layouts/content/company-details.marko
+++ b/packages/global/components/layouts/content/company-details.marko
@@ -41,7 +41,7 @@ $ const showFields = fields.some(k => content[k]);
         <marko-web-content-public-email block-name=blockName obj=content link=true/>
       </div>
       <div class=`${blockName}__field`>
-        <span class=`${blockName}__label`>Webiste:</span>
+        <span class=`${blockName}__label`>Website:</span>
         <marko-web-content-website block-name=blockName obj=content link=true />
       </div>
     </default-theme-content-contact-details-section>


### PR DESCRIPTION
<img width="845" alt="Screen Shot 2023-01-09 at 9 17 46 AM" src="https://user-images.githubusercontent.com/64623209/211343193-4de22118-6a78-47a9-a647-a61b75fac004.png">
