### PR TITLE
Ad related css tweaks

### DIFF
--- a/packages/global/scss/core.scss
+++ b/packages/global/scss/core.scss
@@ -83,7 +83,6 @@ label {
 
 .document-container {
   padding-top: 0;
-  background-color: $white;
 }
 
 .node {
@@ -567,4 +566,27 @@ label {
   &__cta {
     width: auto;
   }
+}
+
+// this is to fix the display of the newsletter pushdown
+.site-newsletter-menu {
+  background-color: $gray-300;
+  z-index: 0;
+  .row {
+    visibility: hidden;
+    opacity: 0;
+    transition:visibility 0.3s linear,opacity 0.3s linear;
+  }
+  &--open {
+    .row {
+      visibility: visible;
+      opacity: 1;
+    }
+  }
+}
+
+// Prevent Billboard from breaking out of document-container
+.ad-container--inter-block {
+  margin-right: 0;
+  margin-left: 0;
 }


### PR DESCRIPTION
 - Remove bckground color on document-container
 - Adjust newsletter pushdown menu to have better transition and account for reskin ad & background colors
 - no longer display billboard ad outside document container.
 
 
<img width="1397" alt="Screen Shot 2023-01-10 at 1 44 54 PM" src="https://user-images.githubusercontent.com/3845869/211647784-91df6acb-28d0-44cc-9eaf-65bcdef28492.png">
<img width="1411" alt="Screen Shot 2023-01-10 at 1 45 11 PM" src="https://user-images.githubusercontent.com/3845869/211647801-9b37cc12-9027-4a49-a7c7-820d04767d8a.png">
