### PR TITLE
Prevert error when storing Auth0 external ids

### DIFF
--- a/packages/auth0/after-callback.js
+++ b/packages/auth0/after-callback.js
@@ -34,19 +34,24 @@ module.exports = async (req, res, session) => {
   // federate trusted verification state to IdX and log in via impersonation api
   try {
     const appUser = await service.createAppUser({ email });
-    await Promise.all([
-      service.impersonateAppUser({ userId: appUser.id }),
-      service.addExternalUserId({
+    await service.impersonateAppUser({ userId: appUser.id });
+    debug('impersonated', appUser.id);
+
+    try {
+      // Attempt to store Auth0 ids
+      await service.addExternalUserId({
         userId: appUser.id,
         identifier: { value: user.sub },
-        namespace: {
-          provider: 'auth0',
-          tenant,
-          type: 'user',
-        },
-      }),
-    ]);
-    debug('impersonated', appUser.id);
+        namespace: { provider: 'auth0', tenant, type: 'user' },
+      });
+    } catch (e) {
+      await service.addExternalUserId({
+        userId: appUser.id,
+        identifier: { value: Buffer.from(user.sub).toString('base64'), type: 'base64' },
+        namespace: { provider: 'auth0', tenant, type: 'user' },
+      });
+      debug('Unable to store raw auth0 external id', e.message);
+    }
   } catch (e) {
     debug('autherr', e, e.message);
     if (/Please enter a valid email address/.test(e.message)) {


### PR DESCRIPTION
Explicitly catch errors saving external ids to prevent authentication failures.