### PR TITLE
Remove ‘billboard’ ad placement

### DIFF
--- a/packages/global/config/gam.js
+++ b/packages/global/config/gam.js
@@ -21,16 +21,16 @@ module.exports = ({
         { viewport: [320, 0], size: [[300, 50], [320, 50]] },
       ],
     })
-    .setTemplate('BILLBOARD', {
-      size: [
-        [970, 250],
-        [300, 250],
-      ],
-      sizeMapping: [
-        { viewport: [980, 0], size: [970, 250] },
-        { viewport: [320, 0], size: [300, 250] },
-      ],
-    })
+    // .setTemplate('BILLBOARD', {
+    //   size: [
+    //     [970, 250],
+    //     [300, 250],
+    //   ],
+    //   sizeMapping: [
+    //     { viewport: [980, 0], size: [970, 250] },
+    //     { viewport: [320, 0], size: [300, 250] },
+    //   ],
+    // })
     .setTemplate('LEADERBOARD', {
       size: [
         [970, 90],

--- a/sites/labpulse.com/config/gam.js
+++ b/sites/labpulse.com/config/gam.js
@@ -13,7 +13,7 @@ config.lazyLoad = {
 
 config.setAliasAdUnits('default', [
   { name: 'lb-sticky-bottom', templateName: 'LB-STICKY-BOTTOM', path: 'leaderboard' },
-  { name: 'billboard', templateName: 'BILLBOARD', path: 'billboard' },
+  // { name: 'billboard', templateName: 'BILLBOARD', path: 'billboard' },
   { name: 'leaderboard', templateName: 'LEADERBOARD', path: 'leaderboard' },
   { name: 'rotation', templateName: 'ROTATION', path: 'rotation' },
   { name: 'inline-content-mobile', templateName: 'INLINE-CONTENT-MOBILE', path: 'rotation' },
@@ -32,7 +32,7 @@ const aliases = [
 
 aliases.forEach(alias => config.setAliasAdUnits(alias, [
   { name: 'leaderboard', templateName: 'LEADERBOARD', path: `${alias}-leaderboard` },
-  { name: 'billboard', templateName: 'BILLBOARD', path: `${alias}-billboard` },
+  // { name: 'billboard', templateName: 'BILLBOARD', path: `${alias}-billboard` },
   { name: 'rotation', templateName: 'ROTATION', path: `${alias}-rotation` },
   { name: 'inline-content-mobile', templateName: 'INLINE-CONTENT-MOBILE', path: `${alias}-rotation` },
   { name: 'inline-content-desktop', templateName: 'INLINE-CONTENT-DESKTOP', path: `${alias}-rotation` },


### PR DESCRIPTION
Current:
<img width="1596" alt="Screen Shot 2023-01-22 at 8 17 49 PM" src="https://user-images.githubusercontent.com/64623209/213955576-2f91833a-251c-44fe-ba3a-0d3485b7df61.png">

Removed:
<img width="1284" alt="Screen Shot 2023-01-22 at 8 16 15 PM" src="https://user-images.githubusercontent.com/64623209/213955507-d36bf0db-819e-4508-9058-92ff892f9354.png">
