### PR TITLE
Change all newsletter signup buttons color to ‘red’, Dr. Bicuspid

### DIFF
--- a/sites/drbicuspid.com/server/styles/index.scss
+++ b/sites/drbicuspid.com/server/styles/index.scss
@@ -8,6 +8,7 @@ $theme-site-header-breakpoints: (
 
 // Colors
 $primary: #01274b;
+$red: #e31c3d;
 
 @import "../../node_modules/@science-medicine-group/package-global/scss/core";
 
@@ -22,13 +23,16 @@ $primary: #01274b;
   background-color: #f0f1f2;
 }
 
-.btn-primary {
-  background-color: #448439;
+.newsletter-signup-banner {
+  &__cta {
+    .btn-primary {
+      background-color: $red;
+    }
+  }
 }
-
 .site-newsletter-menu {
   &__form-button {
-    background-color: #448439;
+    background-color: $red;
   }
 }
 


### PR DESCRIPTION
Pushdown Menu:
<img width="1211" alt="Screen Shot 2023-02-07 at 11 41 55 AM" src="https://user-images.githubusercontent.com/64623209/217329352-c08d3a69-27b0-46a1-83b7-a32c73b87589.png">
Right Rail:
<img width="460" alt="Screen Shot 2023-02-07 at 11 44 40 AM" src="https://user-images.githubusercontent.com/64623209/217329363-446a5394-a719-4434-a6e2-8b61e26bfcc0.png">
In-line Content:
<img width="781" alt="Screen Shot 2023-02-07 at 11 44 54 AM" src="https://user-images.githubusercontent.com/64623209/217329365-a176fd98-6f21-4b5b-b917-7d15600756f6.png">
Footer & showing 'Next Page' button still reads $primary color
<img width="1542" alt="Screen Shot 2023-02-07 at 12 06 02 PM" src="https://user-images.githubusercontent.com/64623209/217329366-da6b9a76-bf93-4125-8152-a01d67e1e877.png">
