### PR TITLE
Rotate NativeX ad in ‘Latest in’ block

### DIFF
--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -3,6 +3,7 @@ import contentIframe from "@science-medicine-group/package-global/utils/content-
 import getContentPreview from "@parameter1/base-cms-marko-web-theme-monorail/utils/get-content-preview";
 
 import { cmShowOverlay, cmRestrictContentByReg, cmTruncateBody } from "../../../utils/content-meter-helpers";
+import between from "../../../utils/between";
 
 $ const {
   contentGatingHandler,
@@ -227,7 +228,7 @@ $ const shouldInjectAds = ["article", "video", "news", "podcast"].includes(type)
           query-params={ excludeContentTypes, excludeContentIds: [content.id] }
           class="sticky-top"
         >
-          <@native-x indexes=[0] name="default" aliases=aliases />
+          <@native-x index=between(1,2) name="default" aliases=aliases />
         </theme-latest-content-list-block>
       </div>
     </div>


### PR DESCRIPTION
<img width="1150" alt="Screen Shot 2023-02-13 at 10 33 46 AM" src="https://user-images.githubusercontent.com/64623209/218516502-8f6b96c3-ab66-4163-85c5-21cf923f6dc0.png">
<img width="1368" alt="Screen Shot 2023-02-13 at 10 33 59 AM" src="https://user-images.githubusercontent.com/64623209/218516518-ccca66fe-46d7-43a3-a33b-1f1965071b09.png">
