### PR TITLE
Save roles to IdentityX, include in Braze data

### DIFF
--- a/packages/braze/hooks/on-user-profile-update.js
+++ b/packages/braze/hooks/on-user-profile-update.js
@@ -30,6 +30,10 @@ module.exports = async ({
     }
   });
 
+  // Append the site membership
+  payload.site_membership = { add: brazeConfig.siteName };
+
+  // Apply any site-specific payload customizations
   const formatter = getFormatter(brazeConfig.onUserProfileUpdateFormatter);
   await braze.trackUser(user.email, user.id, await formatter({ service, payload }));
 

--- a/packages/braze/hooks/on-user-profile-update.js
+++ b/packages/braze/hooks/on-user-profile-update.js
@@ -33,9 +33,12 @@ module.exports = async ({
   // Append the site membership
   payload.site_membership = { add: brazeConfig.siteName };
 
+  // Set role if present, fall back to "Account Holder" if not.
+  payload.role = get(user, `customAttributes.${brazeConfig.siteName}Role`) || 'Account Holder';
+
   // Apply any site-specific payload customizations
   const formatter = getFormatter(brazeConfig.onUserProfileUpdateFormatter);
-  await braze.trackUser(user.email, user.id, await formatter({ service, payload }));
+  await braze.trackUser(user.email, user.id, await formatter({ service, payload, user }));
 
   // External ID tagged subscriptions
   const optins = filterByExternalId(getAsArray(user, 'customBooleanFieldAnswers'), 'subscriptionGroup', tenant);

--- a/packages/global/config/braze.js
+++ b/packages/global/config/braze.js
@@ -24,10 +24,7 @@ module.exports = (params = {}) => {
       phoneNumber: 'phone',
       organization: 'org_name',
     },
+    siteName,
     appGroupId,
-    onUserProfileUpdateFormatter: async ({ payload = [] }) => ({
-      ...payload,
-      site_membership: { add: siteName },
-    }),
   };
 };

--- a/packages/global/start-server.js
+++ b/packages/global/start-server.js
@@ -96,7 +96,7 @@ module.exports = (options = {}) => {
       const auth0Config = get(options, 'siteConfig.auth0');
       const icleConfig = getAsObject(options, 'siteConfig.wpIcle');
       // Load ICLE configuration middleware
-      if (icleConfig.enabled) icle(app, { ...icleConfig, idxConfig });
+      if (icleConfig.enabled) icle(app, { ...icleConfig, idxConfig, brazeConfig });
       // Load Auth0+IdentityX
       auth0(app, { ...auth0Config, idxConfig, idxRouteTemplates });
       if (icleConfig.enabled) icleRoutes(app);

--- a/packages/wp-icle/graphql/mutations/update-user.js
+++ b/packages/wp-icle/graphql/mutations/update-user.js
@@ -5,6 +5,7 @@ mutation UpdateUserFromWPICLE(
   $userId: String!,
   $payload: UpdateAppUserPayloadInput!,
   $answers: [UpdateAppUserCustomSelectAnswer!]!
+  $attributes: JSONObject!
 ) {
   updateAppUser(input: {
     id: $userId
@@ -13,6 +14,10 @@ mutation UpdateUserFromWPICLE(
   updateAppUserCustomSelectAnswers(input: {
     id: $userId
     answers: $answers
+  }) { id }
+  updateAppUserCustomAttributes(input: {
+    id: $userId
+    attributes: $attributes
   }) { id }
 }
 `;


### PR DESCRIPTION
When a user is synced from WP-ICLE, the user API `roles` field (https://github.com/parameter1/wordpress-plugin-smg-identity-x/commit/17f6a892463c78a808e33d548d50557d0a287a74) is now used to determine if they are a community member (full/complete profile) or an account holder (default, no special permissions). The role is then saved on the IdentityX user's custom attributes, prefixed with the Braze site name (DrBicuspid).

When a user is updated (or synced), the role saved in IdentityX is included with the Braze track API call under the `role` key.

In all cases, if no role is found, the value `Account Holder` will be used.

![image](https://user-images.githubusercontent.com/1778222/225740230-9fd7196d-c76b-47eb-b4d0-3cd7a5918131.png)
