### PR TITLE
Add sponsored header to content pages

### DIFF
--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -33,7 +33,11 @@ $ const shouldInjectAds = ["article", "video", "news", "podcast"].includes(type)
 >
   <@section|{ blockName, content, aliases, authors }| modifiers=["content-header"]>
     $ const { primarySection } = content;
+    $ const isSponsored = getAsArray(content, "labels").includes("Sponsored");
     <div class="content-page-header">
+      <if(isSponsored)>
+        <div class="content-page-sponsored-header mb-3">Sponsored</div>
+      </if>
       <theme-content-page-breadcrumbs section=primarySection />
       <marko-web-content-name tag="h1" block-name=blockName obj=content />
       <if(type !== "contact")>

--- a/packages/global/scss/core.scss
+++ b/packages/global/scss/core.scss
@@ -592,3 +592,15 @@ label {
   margin-right: 0;
   margin-left: 0;
 }
+
+.content-page-sponsored-header {
+  background-color: #e9ecef;
+  color: #343a40;
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: .2px;
+  line-height: 1.5;
+  padding: 2px 0.75em 1px;
+  text-align: center;
+  text-transform: uppercase;
+}


### PR DESCRIPTION
<img width="1082" alt="Screen Shot 2023-03-20 at 6 42 11 PM" src="https://user-images.githubusercontent.com/2855198/226488925-5a7e7734-dd2d-4248-8185-fc8b8ad721e9.png">
