### PR TITLE
IdentityX/Braze: send data on login, calculate role

### DIFF
--- a/packages/auth0/after-callback.js
+++ b/packages/auth0/after-callback.js
@@ -1,6 +1,7 @@
 const { decode } = require('jsonwebtoken');
 const { get } = require('@parameter1/base-cms-object-path');
 const debug = require('debug')('auth0');
+const callHooksFor = require('@parameter1/base-cms-marko-web-identity-x/utils/call-hooks-for');
 
 /**
  * Syncs Auth0 and IdentityX user states
@@ -36,6 +37,8 @@ module.exports = async (req, res, session) => {
     const appUser = await service.createAppUser({ email });
     await service.impersonateAppUser({ userId: appUser.id });
     debug('impersonated', appUser.id);
+    // @todo Remove this if/when hook dispatch is added to impersonateAppUser
+    await callHooksFor(service, 'onAuthenticationSuccess', { req, res, user: appUser });
 
     try {
       // Attempt to store Auth0 ids

--- a/packages/auth0/after-callback.js
+++ b/packages/auth0/after-callback.js
@@ -25,7 +25,6 @@ module.exports = async (req, res, session) => {
 
   // Destroy A0 context if no email is present
   const { email } = user;
-  debug('user', user);
   if (!email) {
     res.redirect('/user/auth0-no-email');
     throw new Error('Auth0 user must provide an email address.');

--- a/packages/braze/hooks/index.js
+++ b/packages/braze/hooks/index.js
@@ -1,3 +1,4 @@
+const onAuthenticationSuccess = require('./on-authentication-success');
 const onChangeEmailSuccess = require('./on-change-email-success');
 const onUserProfileUpdate = require('./on-user-profile-update');
 
@@ -14,5 +15,11 @@ module.exports = (idxConfig, brazeConfig) => {
     name: 'onChangeEmailSuccess',
     shouldAwait: true,
     fn: (args) => onChangeEmailSuccess({ brazeConfig, ...args }),
+  });
+
+  idxConfig.addHook({
+    name: 'onAuthenticationSuccess',
+    shouldAwait: true,
+    fn: (args) => onAuthenticationSuccess({ brazeConfig, ...args }),
   });
 };

--- a/packages/braze/hooks/on-authentication-success.js
+++ b/packages/braze/hooks/on-authentication-success.js
@@ -1,4 +1,3 @@
-const debug = require('debug')('braze');
 const { buildPayload } = require('../utils');
 
 /**
@@ -11,8 +10,6 @@ module.exports = async ({
 }) => {
   const { req } = service;
   const { braze } = req;
-
-  debug('onAuthenticationSuccess', user);
 
   if (user.verified) {
     // Opt the user out of the 'unconfirmed' group

--- a/packages/braze/hooks/on-authentication-success.js
+++ b/packages/braze/hooks/on-authentication-success.js
@@ -1,0 +1,23 @@
+const debug = require('debug')('braze');
+const { buildPayload } = require('../utils');
+
+/**
+ *
+ */
+module.exports = async ({
+  brazeConfig,
+  user,
+  service,
+}) => {
+  const { req } = service;
+  const { braze } = req;
+
+  const payload = buildPayload({
+    brazeConfig,
+    user,
+    payload: {
+      ...(user.verified && { verification_source: 'Auth0' }),
+    },
+  });
+  await braze.trackUser(user.email, user.id, payload);
+};

--- a/packages/braze/hooks/on-authentication-success.js
+++ b/packages/braze/hooks/on-authentication-success.js
@@ -1,4 +1,3 @@
-const debug = require('debug')('braze');
 const { buildPayload } = require('../utils');
 
 /**

--- a/packages/braze/hooks/on-authentication-success.js
+++ b/packages/braze/hooks/on-authentication-success.js
@@ -1,3 +1,4 @@
+const debug = require('debug')('braze');
 const { buildPayload } = require('../utils');
 
 /**
@@ -10,6 +11,15 @@ module.exports = async ({
 }) => {
   const { req } = service;
   const { braze } = req;
+
+  debug('onAuthenticationSuccess', user);
+
+  if (user.verified) {
+    // Opt the user out of the 'unconfirmed' group
+    await braze.confirmUser(user.email, user.id, 'identity-x');
+  } else {
+    await braze.unconfirmUser(user.email, user.id);
+  }
 
   const payload = buildPayload({
     brazeConfig,

--- a/packages/braze/hooks/on-user-profile-update.js
+++ b/packages/braze/hooks/on-user-profile-update.js
@@ -1,5 +1,5 @@
 const { get, getAsArray } = require('@parameter1/base-cms-object-path');
-const { filterByExternalId, getFormatter } = require('../utils');
+const { filterByExternalId } = require('../utils');
 
 /**
  *
@@ -36,9 +36,8 @@ module.exports = async ({
   // Set role if present, fall back to "Account Holder" if not.
   payload.role = get(user, `customAttributes.${brazeConfig.siteName}Role`) || 'Account Holder';
 
-  // Apply any site-specific payload customizations
-  const formatter = getFormatter(brazeConfig.onUserProfileUpdateFormatter);
-  await braze.trackUser(user.email, user.id, await formatter({ service, payload, user }));
+  // Update Braze with the user data
+  await braze.trackUser(user.email, user.id, payload);
 
   // External ID tagged subscriptions
   const optins = filterByExternalId(getAsArray(user, 'customBooleanFieldAnswers'), 'subscriptionGroup', tenant);

--- a/packages/braze/index.js
+++ b/packages/braze/index.js
@@ -12,6 +12,7 @@ module.exports = (app, params = {}) => {
       external_id: 'id',
       email: 'email',
     }).description('The Braze fields that should be mapped to IdentityX fields.'),
+    unconfirmedGroupId: Joi.string().required().description('The Braze Subscription Group ID to use for unconfirmed users'),
     appGroupId: Joi.string().required().description('The Braze App Group ID to use.'),
   }), params, { allowUnknown: true });
 

--- a/packages/braze/service.js
+++ b/packages/braze/service.js
@@ -10,6 +10,7 @@ class Braze {
     apiKey,
     tenant,
     fieldMap,
+    unconfirmedGroupId,
     appGroupId,
     cookies = {},
   } = {}) {
@@ -20,6 +21,7 @@ class Braze {
       'content-type': 'application/json',
       authorization: `Bearer ${apiKey}`,
     };
+    this.unconfirmedGroupId = unconfirmedGroupId;
     this.appGroupId = appGroupId;
     this.externalId = cookies.braze_ext_id;
     this.internalId = cookies.braze_int_id;
@@ -118,6 +120,33 @@ class Braze {
       description: field.label,
       groupId: get(field, 'externalId.identifier.value'),
     }));
+  }
+
+  /**
+   * Opts the user into the unconfirmed group, sets subscription status, and email validation
+   *
+   * @param {String} email
+   * @param {String} id
+   * @param {String} zeroBounceStatus
+   * @returns {Promise}
+   */
+  unconfirmUser(email, id) {
+    const { unconfirmedGroupId } = this;
+    return Promise.all([
+      this.updateSubscriptions(email, id, { [unconfirmedGroupId]: true }),
+      this.updateSubscriptionStatus(email, false),
+    ]);
+  }
+
+  /**
+   * Opts the user out of the unconfirmed subscription group
+   */
+  confirmUser(email, id) {
+    const { unconfirmedGroupId } = this;
+    return Promise.all([
+      this.updateSubscriptions(email, id, { [unconfirmedGroupId]: false }),
+      this.updateSubscriptionStatus(email, true),
+    ]);
   }
 
   /**

--- a/packages/braze/utils.js
+++ b/packages/braze/utils.js
@@ -1,5 +1,40 @@
-const { getAsObject } = require('@parameter1/base-cms-object-path');
+const { get, getAsArray, getAsObject } = require('@parameter1/base-cms-object-path');
 const updateAppUser = require('./graphql/mutations/idx-user-update-receive-email');
+
+const requiredFields = [
+  'givenName',
+  'familyName',
+  'city',
+  'countryCode',
+  'organization',
+];
+
+const getUserRole = ({
+  user = {},
+  payload = {},
+  defaultRole = 'Account Holder',
+  brazeConfig = {},
+}) => {
+  // Read from incoming payload
+  const incoming = get(payload, 'role');
+  if (incoming && incoming !== defaultRole) return incoming;
+  // Read from custom attributes
+  const attr = get(user, `customAttributes.${brazeConfig.siteName}Role`);
+  if (attr && attr !== defaultRole) return attr;
+
+  // Set role if all required fields are present.
+  if (requiredFields.every(((k) => user[k]))) {
+    // Check for region
+    if ((['US', 'CA', 'MX'].includes(user.countryCode) && user.regionCode) || !user.regionCode) {
+      // Check for all required select fields
+      const questions = getAsArray(user, 'customSelectFieldAnswers').filter(({ field }) => field.required);
+      if (questions.every(({ hasAnswered }) => hasAnswered)) {
+        return 'Community Member';
+      }
+    }
+  }
+  return defaultRole;
+};
 
 module.exports = {
   filterByExternalId: (arr, type, tenant) => arr.filter((v) => {
@@ -7,6 +42,16 @@ module.exports = {
     return ns.provider === 'braze' && ns.type === type && ns.tenant === tenant;
   }),
   getFormatter: (v) => (typeof v === 'function' ? v : (x) => x.payload),
+  buildPayload: ({
+    brazeConfig,
+    user = {},
+    payload = {},
+  }) => ({
+    external_id: user.id,
+    site_membership: { add: brazeConfig.siteName },
+    role: getUserRole({ user, brazeConfig }),
+    ...payload,
+  }),
   updateIdentityXUser: async (email, svc, answers) => {
     const user = await svc.createAppUser({ email });
     const apiToken = svc.config.getApiToken();

--- a/packages/global/config/braze.js
+++ b/packages/global/config/braze.js
@@ -4,9 +4,11 @@ const { validate } = require('@parameter1/joi/utils');
 module.exports = (params = {}) => {
   const {
     siteName,
+    unconfirmedGroupId,
     appGroupId,
   } = validate(Joi.object({
     siteName: Joi.string().required().description('The Braze site membership identifier.'),
+    unconfirmedGroupId: Joi.string().required().description('The Braze Subscription Group ID to use for unconfirmed users'),
     appGroupId: Joi.string().required().description('The Braze App Group ID to use.'),
   }), params);
 
@@ -24,6 +26,7 @@ module.exports = (params = {}) => {
       phoneNumber: 'phone',
       organization: 'org_name',
     },
+    unconfirmedGroupId,
     siteName,
     appGroupId,
   };

--- a/sites/auntminnie.com/config/braze.js
+++ b/sites/auntminnie.com/config/braze.js
@@ -2,5 +2,6 @@ const config = require('@science-medicine-group/package-global/config/braze');
 
 module.exports = config({
   siteName: 'AM',
+  unconfirmedGroupId: '~not-set~',
   appGroupId: '634d675d1118243d1113480e',
 });

--- a/sites/auntminnieasia.com/config/braze.js
+++ b/sites/auntminnieasia.com/config/braze.js
@@ -2,5 +2,6 @@ const config = require('@science-medicine-group/package-global/config/braze');
 
 module.exports = config({
   siteName: 'AMA',
+  unconfirmedGroupId: '~not-set~',
   appGroupId: '634d675d1118243d1113480e',
 });

--- a/sites/auntminnieeurope.com/config/braze.js
+++ b/sites/auntminnieeurope.com/config/braze.js
@@ -2,5 +2,6 @@ const config = require('@science-medicine-group/package-global/config/braze');
 
 module.exports = config({
   siteName: 'AME',
+  unconfirmedGroupId: '~not-set~',
   appGroupId: '634d675d1118243d1113480e',
 });

--- a/sites/drbicuspid.com/config/braze.js
+++ b/sites/drbicuspid.com/config/braze.js
@@ -2,5 +2,6 @@ const config = require('@science-medicine-group/package-global/config/braze');
 
 module.exports = config({
   siteName: 'DrBicuspid',
+  unconfirmedGroupId: '3a0e5e67-8fd8-41fd-979e-c4f834815e4c',
   appGroupId: '634d67c3ee91fe5375c3bcac',
 });

--- a/sites/labpulse.com/config/braze.js
+++ b/sites/labpulse.com/config/braze.js
@@ -2,5 +2,6 @@ const config = require('@science-medicine-group/package-global/config/braze');
 
 module.exports = config({
   siteName: 'LabPulse',
+  unconfirmedGroupId: '75f0a01f-de6b-4b8c-95d9-a0e516280aa8',
   appGroupId: '6321cf49247c426e9256f6d0',
 });

--- a/sites/scienceboard.net/config/braze.js
+++ b/sites/scienceboard.net/config/braze.js
@@ -2,5 +2,6 @@ const config = require('@science-medicine-group/package-global/config/braze');
 
 module.exports = config({
   siteName: 'SAB',
+  unconfirmedGroupId: '~not-set~',
   appGroupId: '634d62e10ef4e37a75846f41',
 });


### PR DESCRIPTION
- [x] Adds hook to send data to Braze on login/auth. Inadvertently removed in #144 and #145
- [x] Calculate role when building an update payload