### PR TITLE
IdentityX/ICLE sync failures

### DIFF
--- a/packages/wp-icle/routes/update-identityx-users.js
+++ b/packages/wp-icle/routes/update-identityx-users.js
@@ -197,11 +197,10 @@ module.exports = (app) => {
       })).json();
 
       // Change to all
-      await Promise.all(profiles.map(async (profile) => {
-        const { user_email: email } = profile;
+      await Promise.all([...emails.keys()].map(async (email) => {
         try {
-          if (!email) throw new Error(`User could not be loaded by email ${email}`);
-          // @todo handle ids/externalId for changed emails?
+          const profile = profiles.find((p) => p.user_email === email);
+          if (!profile) throw new Error(`User profile was not returned for ${email}!`);
           const payload = await buildPayload({ svc, profile, config });
           const user = await svc.createAppUser({ email });
           await updateUser(svc, payload, user);


### PR DESCRIPTION
Fixes bug introduced in #219 that was incorrectly marking syncs without data as passing.