### PR TITLE
Fix change email implementation

### DIFF
--- a/packages/auth0/hooks/index.js
+++ b/packages/auth0/hooks/index.js
@@ -1,15 +1,9 @@
 const onChangeEmailSuccess = require('./on-change-email-success');
 
-module.exports = (app, idxConfig, auth0Config) => {
-  // Wrap this in a middleware so that the resolved user object can be passed to the IdentityX hook
-  app.use((req, _, next) => {
-    const { user } = req.oidc;
-    // Handle changeEmail success
-    idxConfig.addHook({
-      name: 'onChangeEmailSuccess',
-      shouldAwait: true,
-      fn: (args) => onChangeEmailSuccess({ auth0Config, auth0User: user, ...args }),
-    });
-    next();
+module.exports = (idxConfig, auth0Config) => {
+  idxConfig.addHook({
+    name: 'onChangeEmailSuccess',
+    shouldAwait: true,
+    fn: (args) => onChangeEmailSuccess({ auth0Config, ...args }),
   });
 };

--- a/packages/auth0/hooks/on-change-email-success.js
+++ b/packages/auth0/hooks/on-change-email-success.js
@@ -8,9 +8,8 @@ module.exports = async ({
   user,
   service,
   oldEmail,
-  auth0User,
 }) => {
   const auth0 = get(service, 'req.auth0');
-  await auth0.changeEmailAddress(user.email, auth0User.sub);
+  await auth0.changeEmailAddress(user.email, oldEmail);
   debug(`User ${user.id} changed email from ${oldEmail} to ${user.email}!`);
 };

--- a/packages/auth0/middleware/index.js
+++ b/packages/auth0/middleware/index.js
@@ -49,7 +49,6 @@ module.exports = (app, params = {}) => {
     const isIdentified = Boolean(req.identityX.token);
     const canRedirect = !/^\/user\/auth0-db-email-verification/.test(req.url);
     if (isAuthenticated && isIdentified && canRedirect) {
-      debug('Checking email verification', user);
       if (user && user.requireVerification) {
         // Log out of IdX
         await req.identityX.logoutAppUser(); // @todo fix upstream error when no token present

--- a/packages/auth0/service.js
+++ b/packages/auth0/service.js
@@ -2,7 +2,7 @@ const { get } = require('@parameter1/base-cms-object-path');
 const Joi = require('@parameter1/joi');
 const { validate } = require('@parameter1/joi/utils');
 const fetch = require('node-fetch');
-const debug = require('debug')('auth0');
+const debug = require('debug')('auth0-api');
 
 class Auth0 {
   constructor(params = {}) {
@@ -110,6 +110,7 @@ class Auth0 {
       method: 'patch',
       body: JSON.stringify({
         email,
+        name: email, // Set name to new email (to reduce confusion)
         email_verified: true, // IdX verified
         verify_email: false, // Don't send a verification email for this request
       }),

--- a/packages/auth0/service.js
+++ b/packages/auth0/service.js
@@ -1,3 +1,4 @@
+const { get } = require('@parameter1/base-cms-object-path');
 const Joi = require('@parameter1/joi');
 const { validate } = require('@parameter1/joi/utils');
 const fetch = require('node-fetch');
@@ -90,12 +91,21 @@ class Auth0 {
   }
 
   /**
-   * Changes the email address of the currently logged-in user.
+   * Changes the email address of an Auth0 user.
+   *
+   * @see https://auth0.com/docs/api/management/v2#!/Users_By_Email/get_users_by_email
    * @see https://auth0.com/docs/api/management/v2#!/Users/patch_users_by_id
    */
-  changeEmailAddress(email, userId) {
+  async changeEmailAddress(email, oldEmail) {
     if (!email) throw new Error('You must supply the new email address!');
-    if (!userId) throw new Error('You must supply the Auth0 user id!');
+    if (!oldEmail) throw new Error('You must supply the old email address!');
+    const params = new URLSearchParams({
+      include_fields: false,
+      email: oldEmail,
+    });
+    const users = await this.request(`api/v2/users-by-email?${params}`, { method: 'get' });
+    const userId = get(users, '0.user_id');
+    if (!userId) throw new Error('Unable to find Auth0 user using old email address!');
     return this.request(`api/v2/users/${userId}`, {
       method: 'patch',
       body: JSON.stringify({

--- a/packages/auth0/service.js
+++ b/packages/auth0/service.js
@@ -51,7 +51,6 @@ class Auth0 {
       }),
     });
     const response = await r.json();
-    debug('fetchToken', response);
     if (!r.ok || !response.access_token) throw new Error(`API request was unsuccessful: ${r.status} ${r.statusText}`);
     return response.access_token;
   }

--- a/packages/global/start-server.js
+++ b/packages/global/start-server.js
@@ -103,7 +103,7 @@ module.exports = (options = {}) => {
 
       // Add hooks
       brazeHooks(idxConfig, brazeConfig);
-      auth0Hooks(app, idxConfig, auth0Config);
+      auth0Hooks(idxConfig, auth0Config);
       if (icleConfig.enabled) icleHooks(idxConfig, icleConfig);
 
       // i18n

--- a/packages/wp-icle/hooks/index.js
+++ b/packages/wp-icle/hooks/index.js
@@ -9,7 +9,7 @@ module.exports = (idxConfig, icleConfig) => {
   });
   idxConfig.addHook({
     name: 'onChangeEmailSuccess',
-    shouldAwait: false,
+    shouldAwait: true,
     fn: (args) => onChangeEmailSuccess({ icleConfig, ...args }),
   });
 };


### PR DESCRIPTION
In #142 a bug was introduced by registering the IdentityX `onChangeEmailSuccess` hook inside global middleware. This caused the event to be registered on each page load, and eventually caused a condition where the callback would fire multiple times, with multiple different request contexts (logged in users). This caused a scenario where the wrong user could be updated with a change email request.

The better solution is to just use the incoming email/old email as verified by IdentityX and send an update to Auth0's management API, rather than pulling the active user from the request.