### PR TITLE
Change email: reload page/messaging after changing email

### DIFF
--- a/packages/auth0/templates/change-email.marko
+++ b/packages/auth0/templates/change-email.marko
@@ -15,7 +15,23 @@ $ const description = `Change your email on ${config.siteName()}`;
         </if>
         <else>
           <p>Enter your new email address below. To complete this process, you must click on the validation link sent to your new email address!</p>
-          <marko-web-identity-x-form-change-email />
+          <if(req.query.sent)>
+            <h4>Almost Done!</h4>
+            <p>
+              We just sent an email with your confirmation link.
+              To finish changing your email, open the email message and click the
+              link within.
+            </p>
+            <p>You have now been logged out. To continue, click the link in your inbox.</p>
+            <p>
+              Note: please check your spam/junk folders.
+              If you do not receive this email, your firewall or ISP has likely blocked it.
+              Please add noreply@identity-x.parameter1.com to your whitelist and try this action again.
+            </p>
+          </if>
+          <else>
+            <marko-web-identity-x-form-change-email />
+          </else>
         </else>
         <p class="mt-2">If you need assistance, please reach out to our <a href="/page/contact-us">support team</a>.</p>
       </@section>

--- a/packages/global/browser/index.js
+++ b/packages/global/browser/index.js
@@ -24,4 +24,9 @@ export default (Browser) => {
 
   // Rudderstack identification
   Browser.register('Rudderstack', Rudderstack, { provide: { EventBus } });
+
+  EventBus.$on('identity-x-change-email-link-sent', () => {
+    // "reload" the page to update user state
+    window.location.search = 'sent=true';
+  });
 };


### PR DESCRIPTION
Reloads the page with custom messaging after initiating an email change, to ensure nav is in sync with the user state.