### PR TITLE
IdentityX+Auth0: Content metering authentication flow

### DIFF
--- a/.auth0/actions/set-verification-state.js
+++ b/.auth0/actions/set-verification-state.js
@@ -1,0 +1,54 @@
+/**
+* Handler that will be called during the execution of a PostLogin flow.
+*
+* @param {Event} event - Details about the user and the context in which they are logging in.
+* @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.
+*/
+// @see https://community.auth0.com/t/how-to-deal-with-unverified-users/91808/3
+exports.onExecutePostLogin = async (event, api) => {
+  const { identities, email_verified } = event.user;
+  const isDbUser = identities.some((id) => id.isSocial === false);
+  api.idToken.setCustomClaim(`isDbUser`, isDbUser);
+  // api.idToken.setCustomClaim('dbg', { q: event.request.query, u: event.user });
+
+  const { verifyEmail } = event.request.query;
+  // If we just verified the email, attempt to load previously stored login source/metadata
+  if (verifyEmail) {
+    const source = event.user.user_metadata['idx_source'] || event.request.query.source;
+    const returnTo = event.user.user_metadata['idx_returnTo'];
+    api.idToken.setCustomClaim('returnTo', returnTo);
+    api.idToken.setCustomClaim('source', source);
+    api.user.setUserMetadata('returnTo', undefined);
+    api.user.setUserMetadata('source', undefined);
+  } else {
+    // const { source, additionalEventData, returnTo } = event.request.query;
+    const { source, returnTo } = event.request.query;
+    if (returnTo) api.user.setUserMetadata('idx_returnTo', returnTo);
+    if (source) api.user.setUserMetadata('idx_source', source);
+    // if (additionalEventData) {
+    //   try {
+    //     const parsed = JSON.parse(additionalEventData);
+    //     Object.entries(parsed).forEach(([key, value]) => {
+    //       api.user.setUserMetadata(`idx_${key}`, value);
+    //     });
+    //   } catch (e) {
+    //     // noop
+    //   }
+    // }
+  }
+
+  if (!email_verified && isDbUser) {
+    // Set custom claim to id token to make available
+    api.idToken.setCustomClaim(`requireVerification`, true);
+  }
+};
+
+/**
+* Handler that will be invoked when this action is resuming after an external redirect. If your
+* onExecutePostLogin function does not perform a redirect, this function can be safely ignored.
+*
+* @param {Event} event - Details about the user and the context in which they are logging in.
+* @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.
+*/
+// exports.onContinuePostLogin = async (event, api) => {
+// };

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -128,12 +128,13 @@ services:
       PORT: 80
       EXPOSED_PORT: 9953
       LIVERELOAD_PORT: 19953
-      AUTH0_BASEURL: http://www-smg-drb.dev.parameter1.com:9953
-      AUTH0_ISSUER_BASEURL: ${AUTH0_ISSUER_BASEURL_DRB-}
       AUTH0_API_AUDIENCE_URL: ${AUTH0_API_AUDIENCE_URL_DRB-}
-      BRAZE_API_KEY: ${BRAZE_API_KEY_DRB}
+      AUTH0_BASEURL: http://www-smg-drb.dev.parameter1.com:9953
+      AUTH0_CLIENTID: ${AUTH0_CLIENTID_DRB}
+      AUTH0_ISSUER_BASEURL: ${AUTH0_ISSUER_BASEURL_DRB-}
       AUTH0_SECRET: ${AUTH0_CLIENT_SECRET_DRB}
       AUTH0_TENANT: ${AUTH0_CLIENT_TENANT_DRB}
+      BRAZE_API_KEY: ${BRAZE_API_KEY_DRB}
       WPICLE_ENABLED: ${WPICLE_ENABLED_DRB-false}
     hostname: www-smg-drb.dev.parameter1.com
     ports:

--- a/packages/auth0/middleware/identity-x.js
+++ b/packages/auth0/middleware/identity-x.js
@@ -41,6 +41,7 @@ module.exports = asyncRoute(async (req, res, next) => {
   if (!req.oidc || !req.identityX) throw new Error('Auth0 and IdentityX must be enabled!');
 
   const { identityX: idxSvc, originalUrl } = req;
+  const { user } = req.oidc;
 
   if (idxSvc.token && req.query.isAuth0Login) {
     const profile = idxSvc.config.getEndpointFor('profile');
@@ -53,7 +54,12 @@ module.exports = asyncRoute(async (req, res, next) => {
       if (url.pathname === profile) {
         res.redirect(302, profile);
       } else {
-        res.redirect(302, `${profile}?returnTo=${encodeURIComponent(returnTo)}`);
+        const usp = new URLSearchParams({
+          returnTo,
+          authenticate: true,
+          loginSource: user.source || 'default',
+        });
+        res.redirect(302, `${profile}?${usp}`);
       }
     } else {
       // Strip the query parameter

--- a/packages/auth0/middleware/index.js
+++ b/packages/auth0/middleware/index.js
@@ -64,6 +64,7 @@ module.exports = (app, params = {}) => {
   // Redirect after login if `returnTo` URL parameter is present.
   if (routes.login === false) {
     app.get('/login', (req, res) => {
+      const { source, additionalEventData } = req.query;
       const referrer = req.query.returnTo || req.get('referrer') || baseURL;
       let returnTo;
       try {
@@ -72,7 +73,19 @@ module.exports = (app, params = {}) => {
         returnTo = new URL(referrer, `${req.protocol}://${req.get('host')}`);
       }
       returnTo.searchParams.append('isAuth0Login', true);
-      res.oidc.login({ returnTo: `${returnTo}` });
+      res.oidc.login({
+        authorizationParams: {
+          // Auth0 defaults
+          response_type: 'id_token',
+          response_mode: 'form_post',
+          scope: 'openid profile email',
+          // Custom kv data
+          source,
+          additionalEventData,
+          returnTo: `${returnTo}`,
+        },
+        returnTo: `${returnTo}`,
+      });
     });
   }
 

--- a/packages/auth0/middleware/index.js
+++ b/packages/auth0/middleware/index.js
@@ -61,6 +61,20 @@ module.exports = (app, params = {}) => {
     next();
   }));
 
+  app.get('/user/verify-email', (req, res) => {
+    res.oidc.login({
+      authorizationParams: {
+        // Auth0 defaults
+        response_type: 'id_token',
+        response_mode: 'form_post',
+        scope: 'openid profile email',
+        // Custom kv data
+        verifyEmail: true,
+      },
+      returnTo: '/',
+    });
+  });
+
   // Redirect after login if `returnTo` URL parameter is present.
   if (routes.login === false) {
     app.get('/login', (req, res) => {

--- a/packages/auth0/middleware/index.js
+++ b/packages/auth0/middleware/index.js
@@ -6,6 +6,8 @@ const { validate } = require('@parameter1/joi/utils');
 const { asyncRoute } = require('@parameter1/base-cms-utils');
 const identityX = require('./identity-x');
 
+const returnToCookieName = '__idxReturnTo';
+
 /**
  *
  */
@@ -56,6 +58,13 @@ module.exports = (app, params = {}) => {
         const usp = new URLSearchParams({ userId: user.sub });
         debug('log out/redirect!', usp);
         res.redirect(302, `/user/auth0-db-email-verification?${usp}`);
+      } else if (user && user.returnTo) {
+        debug(`Redirecting to ${user.returnTo}!`);
+        // We only want to do this once.
+        if (!req.cookies[returnToCookieName]) {
+          res.cookie(returnToCookieName, '1', { maxAge: 900000 });
+          res.redirect(302, user.returnTo);
+        }
       }
     }
     next();

--- a/packages/auth0/middleware/index.js
+++ b/packages/auth0/middleware/index.js
@@ -53,7 +53,7 @@ module.exports = (app, params = {}) => {
         // Log out of IdX
         await req.identityX.logoutAppUser(); // @todo fix upstream error when no token present
         // Redirect to verification notice
-        const usp = new URLSearchParams({ userId: user.sub, returnTo: req.url });
+        const usp = new URLSearchParams({ userId: user.sub });
         debug('log out/redirect!', usp);
         res.redirect(302, `/user/auth0-db-email-verification?${usp}`);
       }

--- a/packages/global/browser/auth0-authenticated.vue
+++ b/packages/global/browser/auth0-authenticated.vue
@@ -1,0 +1,43 @@
+<!-- eslint-disable no-restricted-globals -->
+<template>
+  <div class="auth0-idx-init" style="display: none;" />
+</template>
+
+<script>
+export default {
+  inject: ['EventBus'],
+  props: {
+    activeUser: {
+      type: Object,
+      default: () => {},
+    },
+    source: {
+      type: String,
+      default: '',
+    },
+    additionalEventData: {
+      type: Object,
+      default: () => {},
+    },
+  },
+  created() {
+    const url = new URL(window.location.href);
+    if (this.activeUser.id && this.source) {
+      this.EventBus.$emit('identity-x-authenticated', {
+        id: this.activeUser.id,
+        email: this.activeUser.email,
+        additionalEventData: this.additionalEventData,
+        source: this.source,
+      });
+
+      // Replace the current history entry to strip the additional query params
+      url.searchParams.delete('authenticated');
+      url.searchParams.delete('loginSource');
+      url.searchParams.delete('additionalEventData');
+
+      // eslint-disable-next-line no-restricted-globals
+      history.replaceState(null, null, url);
+    }
+  },
+};
+</script>

--- a/packages/global/browser/form-login.vue
+++ b/packages/global/browser/form-login.vue
@@ -22,7 +22,12 @@
         Register and gain access to premium content, including this article and much more.
         To get started, click the button below.
       </p>
-      <a :href="loginUrl" class="btn btn-primary" :disabled="loading">
+      <a
+        :href="loginUrl"
+        class="btn btn-primary"
+        :disabled="loading"
+        @click="login"
+      >
         Sign in
       </a>
       <p v-if="error" class="mt-3 text-danger">
@@ -93,7 +98,10 @@ export default {
       type: String,
       default: 'Email Address',
     },
-
+    additionalEventData: {
+      type: Object,
+      default: () => ({}),
+    },
     /**
      * Regional consent polices to display (if/when a user selects a country on login)
      * if enabled.
@@ -127,7 +135,12 @@ export default {
      *
      */
     loginUrl() {
-      return `/login?returnTo=${this.redirectTo}`;
+      const params = new URLSearchParams({
+        returnTo: this.redirectTo,
+        source: this.source,
+        additionalEventData: JSON.stringify(this.additionalEventData),
+      });
+      return `/login?${params}`;
     },
 
     /**
@@ -146,6 +159,20 @@ export default {
    */
   mounted() {
     this.emit('login-mounted');
+  },
+
+  /**
+   *
+   */
+  methods: {
+    login() {
+      // @todo do we need to emit `login-link-sent`?
+      // Yes...with beacon probably because of the redirect
+      this.emit('login-link-sent', {
+        source: this.source,
+        additionalEventData: this.additionalEventData,
+      });
+    },
   },
 };
 </script>

--- a/packages/global/browser/index.js
+++ b/packages/global/browser/index.js
@@ -3,6 +3,7 @@ import Auth0 from '@science-medicine-group/package-auth0/browser';
 import Braze from '@science-medicine-group/package-braze/browser';
 import FormLogin from './form-login.vue';
 import Rudderstack from './rudderstack.vue';
+import Auth0Authenticated from './auth0-authenticated.vue';
 
 const GlobalNewsletterMenu = () => import(/* webpackChunkName: "global-newsletter-menu" */ './newsletter-menu.vue');
 const ContentMeterTrack = () => import(/* webpackChunkName: "content-meter-tracker" */ './track-content-meter.vue');
@@ -14,6 +15,9 @@ export default (Browser) => {
     idxArgs: {
       CustomLoginComponent: FormLogin,
     },
+  });
+  Browser.register('Auth0Authenticated', Auth0Authenticated, {
+    provide: { EventBus },
   });
   Browser.register('ContentMeterTrack', ContentMeterTrack);
   Browser.register('GlobalNewsletterMenu', GlobalNewsletterMenu, {

--- a/packages/global/templates/user/profile.marko
+++ b/packages/global/templates/user/profile.marko
@@ -1,6 +1,7 @@
 import { get } from "@parameter1/base-cms-object-path";
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 
-$ const { config } = out.global;
+$ const { config, req } = out.global;
 
 $ // Set the IdentityX default country code from the Maxmind data, if present.
 $ // Note: All local IPs will fail lookups!
@@ -11,6 +12,8 @@ $ if (maxmindDefault && idxOpts) idxOpts.defaultCountryCode = maxmindDefault;
 $ const type = "profile";
 $ const title = `${config.siteName()} Profile`;
 $ const description = `Complete your ${config.siteName()} Profile`;
+$ const loginSource = defaultValue(req.query.loginSource, "default");
+$ const additionalEventData = {}; // @todo
 
 <marko-web-default-page-layout type=type title=title description=description>
   <@head>
@@ -24,10 +27,17 @@ $ const description = `Complete your ${config.siteName()} Profile`;
         <h1 class="page-wrapper__title">${description}</h1>
         <marko-web-identity-x-context|{ user }|>
           <if(user)>
-            <marko-web-identity-x-form-profile />
+            <if(req.query.authenticate)>
+              <marko-web-browser-component name="Auth0Authenticated" props={
+                activeUser: user,
+                source: loginSource,
+                additionalEventData,
+              } />
+            </if>
+            <marko-web-identity-x-form-profile login-source=loginSource />
           </if>
           <else>
-            <marko-web-identity-x-form-login />
+            <marko-web-identity-x-form-login source=loginSource />
           </else>
         </marko-web-identity-x-context>
       </@section>


### PR DESCRIPTION
This change adds support for content metering event emission by adding an `identity-x-login-link-sent` dispatch to the login link click and an `identity-x-authenticated` dispatch when visiting the profile after authentication.

Additionally, this preserves the login source by sending it through the Auth0 flow, and allows it to be stored temporarily while performing the unverified email authentication flow.

When an unverified email user becomes verified, they will now be automatically logged in, and redirected to the page where they started the authentication process. The login source from that initial point will also be preserved.

Previously, the user would have to click a verification link, which would send them back to the user profile page (without logging them in). The Auth0 verification template can't retrieve user data to add to the post-verification redirect, so it is now being stored in the post-login event (now committed in this repo).

Because of the change to the existing authentication flows, this will likely need to be approved by the SMG team.