### PR TITLE
Update to use related-content nativeX alias

### DIFF
--- a/packages/global/components/layouts/content/default.marko
+++ b/packages/global/components/layouts/content/default.marko
@@ -239,19 +239,21 @@ $ const shouldInjectAds = ["article", "video", "news", "podcast"].includes(type)
           query-params={ excludeContentTypes, excludeContentIds: [content.id] }
           class="sticky-top"
         >
-          <@native-x index=between(1,2) name="default" aliases=aliases />
+          <@native-x index=between(1,2) name="related-content" aliases=aliases />
         </theme-latest-content-list-block>
       </div>
     </div>
   </@section>
 
-  <@section|{ content }|>
+  <@section|{ aliases, content }|>
     <theme-related-stories-block
       content-id=content.id
       section-id=content.primarySection.id
       published=content.published
       with-native-x=true
-    />
+    >
+      <@native-x index=3 name="related-content" aliases=aliases />
+    </theme-related-stories-block>
   </@section>
 
   <!-- <@section|{ aliases }|>

--- a/sites/drbicuspid.com/config/native-x.js
+++ b/sites/drbicuspid.com/config/native-x.js
@@ -7,11 +7,17 @@ config.enabled = process.env.ENABLE_NATIVE_X === 'true';
 config
   .setAliasPlacements('default', [
     { name: 'default', id: '62fce264ffb1230001dca87e' },
-  ]);
-
-config
+    // probably need to set this up!
+    { name: 'related-content', id: '62fce264ffb1230001dca87e' },
+  ])
   .setAliasPlacements('cases', [
     { name: 'cases', id: '6400e1b493fb8e0001c3a6fb' },
+  ])
+  .setAliasPlacements('dental-specialties/endodontics', [
+    { name: 'related-content', id: '6435a1eab91bf50001e2c27b' },
+  ])
+  .setAliasPlacements('dental-specialties/smile-design', [
+    { name: 'related-content', id: '6435a2049eb1640001e88aef' },
   ]);
 
 module.exports = config;


### PR DESCRIPTION
Update to use related-content as the name within nativeX also update the default content layout to use the new related-content nativeX call in right rail and related stories block.

<img width="1067" alt="Screen Shot 2023-04-12 at 9 45 10 AM" src="https://user-images.githubusercontent.com/3845869/231494571-f1df4ac2-3524-46ad-b2b7-84d8c26c7216.png">
<img width="1268" alt="Screen Shot 2023-04-12 at 9 45 38 AM" src="https://user-images.githubusercontent.com/3845869/231494611-edb64be2-ea0c-4ee4-801a-dca17067c8e8.png">
