### PR TITLE
Update AuntMinnie gam config for stickyFooter and Reskin

### DIFF
--- a/sites/auntminnie.com/config/gam.js
+++ b/sites/auntminnie.com/config/gam.js
@@ -2,6 +2,8 @@ const configureGAM = require('@science-medicine-group/package-global/config/gam'
 
 const config = configureGAM({ basePath: 'am' });
 
+config.enableRevealAd = true;
+
 config.lazyLoad = {
   enabled: true, // set to true to enable lazy loading
   fetchMarginPercent: 100, // fetch ad when one viewport away

--- a/sites/auntminnie.com/server/styles/index.scss
+++ b/sites/auntminnie.com/server/styles/index.scss
@@ -10,3 +10,7 @@ $theme-site-header-breakpoints: (
 $primary: #01274b;
 
 @import "@science-medicine-group/package-global/scss/core";
+/*! critical:start */
+@import "@parameter1/base-cms-marko-web-reveal-ad/scss/reveal-ad";
+@import "@parameter1/base-cms-marko-web-theme-monorail/scss/components/reveal-ad";
+/*! critical:end */

--- a/sites/auntminnieasia.com/config/gam.js
+++ b/sites/auntminnieasia.com/config/gam.js
@@ -2,6 +2,8 @@ const configureGAM = require('@science-medicine-group/package-global/config/gam'
 
 const config = configureGAM({ basePath: 'ama' });
 
+config.enableRevealAd = true;
+
 config.lazyLoad = {
   enabled: true, // set to true to enable lazy loading
   fetchMarginPercent: 100, // fetch ad when one viewport away
@@ -10,18 +12,20 @@ config.lazyLoad = {
 };
 
 config.setAliasAdUnits('default', [
-  { name: 'lb-sticky-bottom', templateName: 'LB-STICKY-BOTTOM', path: 'leaderboard' },
+  { name: 'lb-sticky-bottom', templateName: 'LB-STICKY-BOTTOM', path: 'sticky-leaderboard' },
   { name: 'leaderboard', templateName: 'LEADERBOARD', path: 'leaderboard' },
   { name: 'rotation', templateName: 'ROTATION', path: 'rotation' },
   { name: 'inline-content-mobile', templateName: 'INLINE-CONTENT-MOBILE', path: 'rotation' },
   { name: 'inline-content-desktop', templateName: 'INLINE-CONTENT-DESKTOP', path: 'rotation' },
-  // Below based on enableRevealAd
-  // { name: 'reskin', path: 'reskin' },
+  { name: 'reskin', path: 'reskin' },
 ]);
 
-const aliases = [];
+const aliases = [
+  { alias: 'imaging-informatics' },
+];
 
 aliases.forEach((alias) => config.setAliasAdUnits(alias, [
+  { name: 'lb-sticky-bottom', templateName: 'LB-STICKY-BOTTOM', path: `${alias}-sticky-footer` },
   { name: 'leaderboard', templateName: 'LEADERBOARD', path: `${alias}-leaderboard` },
   { name: 'rotation', templateName: 'ROTATION', path: `${alias}-rotation` },
   { name: 'inline-content-mobile', templateName: 'INLINE-CONTENT-MOBILE', path: `${alias}-rotation` },

--- a/sites/auntminnieasia.com/server/styles/index.scss
+++ b/sites/auntminnieasia.com/server/styles/index.scss
@@ -10,3 +10,7 @@ $theme-site-header-breakpoints: (
 $primary: #01274b;
 
 @import "@science-medicine-group/package-global/scss/core";
+/*! critical:start */
+@import "@parameter1/base-cms-marko-web-reveal-ad/scss/reveal-ad";
+@import "@parameter1/base-cms-marko-web-theme-monorail/scss/components/reveal-ad";
+/*! critical:end */

--- a/sites/auntminnieeurope.com/config/gam.js
+++ b/sites/auntminnieeurope.com/config/gam.js
@@ -2,6 +2,8 @@ const configureGAM = require('@science-medicine-group/package-global/config/gam'
 
 const config = configureGAM({ basePath: 'ame' });
 
+config.enableRevealAd = true;
+
 config.lazyLoad = {
   enabled: true, // set to true to enable lazy loading
   fetchMarginPercent: 100, // fetch ad when one viewport away
@@ -10,18 +12,20 @@ config.lazyLoad = {
 };
 
 config.setAliasAdUnits('default', [
-  { name: 'lb-sticky-bottom', templateName: 'LB-STICKY-BOTTOM', path: 'leaderboard' },
+  { name: 'lb-sticky-bottom', templateName: 'LB-STICKY-BOTTOM', path: 'sticky-footer' },
   { name: 'leaderboard', templateName: 'LEADERBOARD', path: 'leaderboard' },
   { name: 'rotation', templateName: 'ROTATION', path: 'rotation' },
   { name: 'inline-content-mobile', templateName: 'INLINE-CONTENT-MOBILE', path: 'rotation' },
   { name: 'inline-content-desktop', templateName: 'INLINE-CONTENT-DESKTOP', path: 'rotation' },
-  // Below based on enableRevealAd
-  // { name: 'reskin', path: 'reskin' },
+  { name: 'reskin', path: 'reskin' },
 ]);
 
-const aliases = [];
+const aliases = [
+  { alias: 'imaging-informatics' },
+];
 
 aliases.forEach((alias) => config.setAliasAdUnits(alias, [
+  { name: 'lb-sticky-bottom', templateName: 'LB-STICKY-BOTTOM', path: `${alias}-sticky-footer` },
   { name: 'leaderboard', templateName: 'LEADERBOARD', path: `${alias}-leaderboard` },
   { name: 'rotation', templateName: 'ROTATION', path: `${alias}-rotation` },
   { name: 'inline-content-mobile', templateName: 'INLINE-CONTENT-MOBILE', path: `${alias}-rotation` },

--- a/sites/auntminnieeurope.com/server/styles/index.scss
+++ b/sites/auntminnieeurope.com/server/styles/index.scss
@@ -10,3 +10,7 @@ $theme-site-header-breakpoints: (
 $primary: #01274b;
 
 @import "@science-medicine-group/package-global/scss/core";
+/*! critical:start */
+@import "@parameter1/base-cms-marko-web-reveal-ad/scss/reveal-ad";
+@import "@parameter1/base-cms-marko-web-theme-monorail/scss/components/reveal-ad";
+/*! critical:end */


### PR DESCRIPTION
Ensure reskin, stickyFooter & alias are set
 - Enable reskin on autminne sites includin the css.
 - Ensure the stickiy-footer alias in indeed sticky-footer or ${alias}sticky-footer
 - add ad alias for imaging-infomatics for all three auntMinnie sites
 - also included the required css at the site level for the reskin to display correctly.  
 
 Staging PR: https://github.com/parameter1/science-medicine-group-websites/pull/327

<img width="1186" alt="Screen Shot 2023-06-12 at 1 05 40 PM" src="https://github.com/parameter1/science-medicine-group-websites/assets/3845869/e99c052c-9d13-4642-b377-5b8888484b3b">


