### PR TITLE
Add 'whitepaper' to nav (labpulse) & remove leaderboard on whitepaper layout

### DIFF
--- a/packages/global/components/layouts/content/whitepaper.marko
+++ b/packages/global/components/layouts/content/whitepaper.marko
@@ -9,14 +9,6 @@ $ const { id, type, pageNode, ...rest } = input;
   page-node=pageNode
   ...rest
 >
-  <@section|{ aliases }| modifiers=["first-sm"]>
-    <theme-gam-define-display-ad
-      name="leaderboard"
-      position="content_page"
-      aliases=aliases
-      modifiers=["inter-block"]
-    />
-  </@section>
 
   <@section|{ blockName, content, aliases }| modifiers=["content-header"]>
     $ const { primarySection } = content;

--- a/sites/labpulse.com/config/navigation.js
+++ b/sites/labpulse.com/config/navigation.js
@@ -41,6 +41,7 @@ const resources = [
   { href: '/resources/videos', label: 'Videos' },
   { href: '/resources/webinars', label: 'Webinars' },
   { href: '/resources/media-press', label: 'Media & Press' },
+  { href: '/resources/whitepapers', lable: 'Whitepapers' },
   { href: '/page/advertising', label: 'Advertising' },
 ];
 

--- a/sites/labpulse.com/config/navigation.js
+++ b/sites/labpulse.com/config/navigation.js
@@ -41,7 +41,7 @@ const resources = [
   { href: '/resources/videos', label: 'Videos' },
   { href: '/resources/webinars', label: 'Webinars' },
   { href: '/resources/media-press', label: 'Media & Press' },
-  { href: '/resources/whitepapers', lable: 'Whitepapers' },
+  { href: '/resources/whitepapers', label: 'Whitepapers' },
   { href: '/page/advertising', label: 'Advertising' },
 ];
 


### PR DESCRIPTION
<img width="776" alt="Screen Shot 2023-08-31 at 11 24 51 AM" src="https://github.com/parameter1/science-medicine-group-websites/assets/64623209/ccd84eca-7c6d-4334-b61d-bb69c69a454c">
<img width="1111" alt="Screen Shot 2023-08-31 at 11 27 35 AM" src="https://github.com/parameter1/science-medicine-group-websites/assets/64623209/31719d2f-51bf-41d3-935e-f78d3d660b18">
<img width="1196" alt="Screen Shot 2023-08-31 at 12 25 11 PM" src="https://github.com/parameter1/science-medicine-group-websites/assets/64623209/e316ef69-caf0-4a56-834a-f8a32f4c44c6">
