### PR TITLE
Passthrough user id on login link sent Rudderstack

### DIFF
--- a/packages/global/browser/rudderstack.vue
+++ b/packages/global/browser/rudderstack.vue
@@ -17,8 +17,8 @@ export default {
     },
   },
   created() {
-    this.EventBus.$on('identity-x-login-link-sent', ({ email }) => {
-      identify(window)({ email });
+    this.EventBus.$on('identity-x-login-link-sent', (payload) => {
+      identify(window)(payload.data?.appUser?.id, { email: payload.email });
     });
     this.EventBus.$on('identity-x-authenticated', ({ id, email }) => {
       identify(window)(id, { email });


### PR DESCRIPTION
Console showing what this value should look like:
![Screenshot from 2023-10-05 12-31-40](https://github.com/parameter1/science-medicine-group-websites/assets/46794001/1db8bac5-caa4-442f-9cc8-d4f4404075f4)
