### PR TITLE
Add 2023 to page-detail for RSNA

### DIFF
--- a/sites/auntminnie.com/config/page-details.js
+++ b/sites/auntminnie.com/config/page-details.js
@@ -1,4 +1,5 @@
 const rsnaSiblingRoutes = [
+  { title: 2023, href: 'resources/conference/rsna/2023', alt: '2023 Radiological Society of North America (RSNA News Coverage' },
   { title: 2022, href: 'resources/conference/rsna/2022', alt: '2022 Radiological Society of North America (RSNA) News Coverage' },
   { title: 2021, href: 'resources/conference/rsna/2021', alt: '2021 Radiological Society of North America (RSNA) News Coverage' },
   { title: 2020, href: 'resources/conference/rsna/2020', alt: '2020 Radiological Society of North America (RSNA) News Coverage' },
@@ -45,6 +46,10 @@ module.exports = {
       alt: 'RSNA News Coverage',
     },
     teaserCTA: 'View Latest Coverage',
+  },
+  'resources/conference/rsna/2023': {
+    name: '2023 Radiological Society of North America (RSNA) News Coverage',
+    siblinRoutes: rsnaSiblingRoutes,
   },
   'resources/conference/rsna/2022': {
     name: '2022 Radiological Society of North America (RSNA) News Coverage',

--- a/sites/auntminnie.com/config/page-details.js
+++ b/sites/auntminnie.com/config/page-details.js
@@ -53,19 +53,19 @@ module.exports = {
   },
   'resources/conference/rsna/2022': {
     name: '2022 Radiological Society of North America (RSNA) News Coverage',
-    siblinRoutes: rsnaSiblingRoutes,
+    siblingRoutes: rsnaSiblingRoutes,
   },
   'resources/conference/rsna/2021': {
     name: '2021 Radiological Society of North America (RSNA) News Coverage',
-    siblinRoutes: rsnaSiblingRoutes,
+    siblingRoutes: rsnaSiblingRoutes,
   },
   'resources/conference/rsna/2020': {
     name: '2020 Radiological Society of North America (RSNA) News Coverage',
-    siblinRoutes: rsnaSiblingRoutes,
+    siblingRoutes: rsnaSiblingRoutes,
   },
   'resources/conference/rsna/2019': {
     name: '2019 Radiological Society of North America (RSNA) News Coverage',
-    siblinRoutes: rsnaSiblingRoutes,
+    siblingRoutes: rsnaSiblingRoutes,
   },
   // European Congress of Radiology (ECR) News Coverage
   'resources/conference/ecr': {
@@ -82,15 +82,15 @@ module.exports = {
   },
   'resources/conference/ecr/2023': {
     name: '2023 European Congress of Radiology (ECR) News Coverage',
-    siblinRoutes: ecrSiblingRoutes,
+    siblingRoutes: ecrSiblingRoutes,
   },
   'resources/conference/ecr/2019': {
     name: '2019 European Congress of Radiology (ECR) News Coverage',
-    siblinRoutes: ecrSiblingRoutes,
+    siblingRoutes: ecrSiblingRoutes,
   },
   'resources/conference/ecr/2018': {
     name: '2018 European Congress of Radiology (ECR) News Coverage',
-    siblinRoutes: ecrSiblingRoutes,
+    siblingRoutes: ecrSiblingRoutes,
   },
   // International Society for Magnetic Resonance in Medicine (ISMRM) News Coverage
   'resources/conference/ismrm': {
@@ -107,19 +107,19 @@ module.exports = {
   },
   'resources/conference/ismrm/2022': {
     name: '2022  International Society of Magnetic Resonance (ISMRM) News Coverage',
-    siblinRoutes: ismrmSiblingRoutes,
+    siblingRoutes: ismrmSiblingRoutes,
   },
   'resources/conference/ismrm/2021': {
     name: '2021  International Society of Magnetic Resonance (ISMRM) News Coverage',
-    siblinRoutes: ismrmSiblingRoutes,
+    siblingRoutes: ismrmSiblingRoutes,
   },
   'resources/conference/ismrm/2020': {
     name: '2020  International Society of Magnetic Resonance (ISMRM) News Coverage',
-    siblinRoutes: ismrmSiblingRoutes,
+    siblingRoutes: ismrmSiblingRoutes,
   },
   'resources/conference/ismrm/2019': {
     name: '2019  International Society of Magnetic Resonance (ISMRM) News Coverage',
-    siblinRoutes: ismrmSiblingRoutes,
+    siblingRoutes: ismrmSiblingRoutes,
   },
   // American Healthcare Radiology Administrators (AHRA) News Coverage
   'resources/conference/ahra': {
@@ -136,10 +136,10 @@ module.exports = {
   },
   'resources/conference/ahra/2022': {
     name: '2022 American Healthcare Radiology Administrators (AHRA) News Coverage',
-    siblinRoutes: ahraSiblingRoutes,
+    siblingRoutes: ahraSiblingRoutes,
   },
   'resources/conference/ahra/2021': {
     name: '2021 American Healthcare Radiology Administrators (AHRA) News Coverage',
-    siblinRoutes: ahraSiblingRoutes,
+    siblingRoutes: ahraSiblingRoutes,
   },
 };

--- a/sites/auntminnie.com/server/templates/website-section/conference-with-pinned.marko
+++ b/sites/auntminnie.com/server/templates/website-section/conference-with-pinned.marko
@@ -24,7 +24,7 @@ $ const pageDetails = site.getAsObject(`pageDetails.${alias}`);
         aliases=[alias]
         modifiers=["inline-section-feed"]
       />
-      $ const siblings = getAsArray(pageDetails, "siblinRoutes").filter(({ href })=> href !== alias);
+      $ const siblings = getAsArray(pageDetails, "siblingRoutes").filter(({ href })=> href !== alias);
        <marko-web-node-list class="mt-block" modifiers=["past-coverage", "flush-x"]>
         <@header>
           Additional Coverage


### PR DESCRIPTION
This will allow the ‘previous coverage’ block to appear
<img width="801" alt="Screen Shot 2023-11-08 at 5 15 21 PM" src="https://github.com/parameter1/science-medicine-group-websites/assets/64623209/97ad48f2-4d03-44e9-b848-63aa627f5c93">
