### PR TITLE
Fix missed misspelled ‘siblingRoutes’

### DIFF
--- a/sites/auntminnie.com/config/page-details.js
+++ b/sites/auntminnie.com/config/page-details.js
@@ -49,7 +49,7 @@ module.exports = {
   },
   'resources/conference/rsna/2023': {
     name: '2023 Radiological Society of North America (RSNA) News Coverage',
-    siblinRoutes: rsnaSiblingRoutes,
+    siblingRoutes: rsnaSiblingRoutes,
   },
   'resources/conference/rsna/2022': {
     name: '2022 Radiological Society of North America (RSNA) News Coverage',


### PR DESCRIPTION
<img width="763" alt="Screen Shot 2023-11-09 at 11 11 43 AM" src="https://github.com/parameter1/science-medicine-group-websites/assets/64623209/cfe4565b-b751-4a62-b890-a43b01e71ba8">
