### PR TITLE
Envoke `rudderstack.identify` with valid `braze_ext_id` values from query string

### DIFF
--- a/packages/braze/components/identify.marko
+++ b/packages/braze/components/identify.marko
@@ -1,0 +1,15 @@
+import { getResponseCookies } from "@parameter1/base-cms-utils";
+
+$ const { req, res } = out.global;
+$ const { identityX } = req;
+$ const cookies = { ...req.cookies, ...getResponseCookies(res) };
+$ const brazeIntId = cookies.braze_int_id;
+$ const brazeExtId = cookies.braze_ext_id;
+
+<if(Boolean(identityX))>
+  <marko-web-resolve|{ resolved: user }| promise=identityX.getIdentityData()>
+    <if(user || brazeIntId || brazeExtId)>
+      <marko-web-identity-x-identify provider-data={ braze_int_id: brazeIntId, braze_ext_id: brazeExtId } />
+    </if>
+  </marko-web-resolve>
+</if>

--- a/packages/braze/components/marko.json
+++ b/packages/braze/components/marko.json
@@ -1,0 +1,6 @@
+{
+  "taglib-imports": [],
+  "<braze-identity-x-identify>": {
+    "template": "./identify.marko"
+  }
+}

--- a/packages/braze/marko.json
+++ b/packages/braze/marko.json
@@ -1,0 +1,5 @@
+{
+  "taglib-imports": [
+    "./components/marko.json"
+  ]
+}

--- a/packages/braze/package.json
+++ b/packages/braze/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@parameter1/base-cms-env": "^4.5.12",
+    "@parameter1/base-cms-marko-core": "^4.40.3",
     "@parameter1/base-cms-marko-web": "^4.40.3",
     "@parameter1/base-cms-marko-web-gtm": "^4.40.3",
     "@parameter1/base-cms-marko-web-identity-x": "^4.40.7",

--- a/packages/global/browser/rudderstack.vue
+++ b/packages/global/browser/rudderstack.vue
@@ -15,6 +15,10 @@ export default {
       type: Object,
       default: () => {},
     },
+    userFromExternalId: {
+      type: Object,
+      default: () => {},
+    },
   },
   created() {
     this.EventBus.$on('identity-x-login-link-sent', (payload) => {
@@ -25,6 +29,10 @@ export default {
     });
     if (this.activeUser && this.activeUser.email) {
       const { id, email } = this.activeUser;
+      identify(window)(id, { email });
+    }
+    if (!this.activeUser && this.userFromExternalId && this.userFromExternalId.email) {
+      const { id, email } = this.userFromExternalId;
       identify(window)(id, { email });
     }
   },

--- a/packages/global/components/document.marko
+++ b/packages/global/components/document.marko
@@ -64,7 +64,7 @@ $ const { gamDefer, gtmDefer, initOnly } = req.query;
 
     <${input.head} />
 
-    <marko-web-identity-x-identify />
+    <braze-identity-x-identify />
 
     <!-- start gtm -->
     <marko-web-gtm-start />

--- a/packages/global/components/rudderstack.marko
+++ b/packages/global/components/rudderstack.marko
@@ -1,5 +1,25 @@
 import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 
-$ const activeUser = defaultValue(input.activeUser, {});
+$ const { req, identityX } = out.global;
 
-<marko-web-browser-component name="Rudderstack" props={ activeUser } />
+$ const activeUser = defaultValue(input.activeUser, {});
+$ const brazeExternalId = req.query['braze_ext_id'];
+
+$ const findUserById = async (externalId) => {
+  try {
+    const userFromId = await identityX.findUserById(externalId);
+    return userFromId;
+  } catch (e) {
+    // Not throwing this since it failing just means there was an invalid lookup attempted
+    console.log(`Unable to find user for external ID, ${externalId}: `,e.message);
+  }
+}
+
+<if(brazeExternalId)>
+  <marko-web-resolve|{ resolved: userFromExternalId }| promise=findUserById(brazeExternalId)>
+    <marko-web-browser-component name="Rudderstack" props={ activeUser, userFromExternalId } />
+  </marko-web-resolve>
+</if>
+<else>
+  <marko-web-browser-component name="Rudderstack" props={ activeUser } />
+</else>


### PR DESCRIPTION
![Screenshot from 2023-11-30 12-20-06](https://github.com/parameter1/science-medicine-group-websites/assets/46794001/925908ea-28de-467b-957c-f34570af2001)


This additionally includes an implementation of a component called `braze-identity-x-identify` which operates similar to the Omeda version implemented as part of https://github.com/parameter1/base-cms/pull/825 (https://github.com/B77Mills/base-cms-1/blob/692e9783134689019d36d658d251415dc1375e9f/packages/marko-web-omeda-identity-x/components/identify.marko), this should theoretically allow us to perform a similar push through to GTM/GA4 for both internal and external Braze IDs (as presently configured).