### PR TITLE
Ensure we have a MongoDB ID before querying for Identity-X user

### DIFF
--- a/packages/braze/middleware/set-idx-cookie.js
+++ b/packages/braze/middleware/set-idx-cookie.js
@@ -13,7 +13,8 @@ module.exports = asyncRoute(async (req, res, next) => {
   if (!identityId) return next(); // no identity to set
 
   // verify that the user exists
-  const identity = await identityX.findUserById(identityId);
+  // This utilizes the same logic for determining a MongoDB ID as base-cms-db's BaseDB.coerceID
+  const identity = /^[a-f0-9]{24}$/.test(identityId) ? await identityX.findUserById(identityId) : null;
   if (!identity) return next(); // invalid or deleted user, don't set an identity
 
   identityX.setIdentityCookie(identity.id);


### PR DESCRIPTION
Oversight from https://github.com/parameter1/science-medicine-group-websites/pull/488 in which we assume the incoming value is always a MongoDB ID, this will now use the same logic as https://github.com/parameter1/base-cms/blob/master/packages/db/src/basedb.js#L509