### PR TITLE
Initial reskin ad adjustment & hiding of ads based on specific sections & content  conditions

### DIFF
--- a/packages/global/components/layouts/content/company.marko
+++ b/packages/global/components/layouts/content/company.marko
@@ -9,6 +9,7 @@ $ const sections = getAsArray(input, "sections");
   id=id
   type=type
   page-node=pageNode
+  with-ads=false
   ...rest
 >
   <@section|{ aliases, blockName, content }| modifiers=["content-header"]>

--- a/packages/global/components/layouts/content/wrapper.marko
+++ b/packages/global/components/layouts/content/wrapper.marko
@@ -64,9 +64,17 @@ $ const loadMore = defaultValue(input.loadMore, true);
       <marko-web-page-container for="content" tag="div" id=id type=type modifiers=["below"]>
         <marko-web-resolve-page|{ data: content, resolved }| node=pageNode>
           $ const aliases = hierarchyAliases(content.primarySection);
+          $ const labels = getAsArray(content, "labels");
+          $ const isSponsored = labels.includes("Sponsored");
+          $ const isPremium = labels.includes('Premium');
+          $ const gamDisabledByAlias = getAsArray(GAM, "disableOnAliases").some((alias) => aliases.includes(alias));
           <marko-web-page-wrapper>
             <@section>
-              <global-section-feed-wrapper aliases=aliases alias=content.primarySection.alias>
+              <global-section-feed-wrapper
+                aliases=aliases
+                alias=content.primarySection.alias
+                with-ads=(withAds && !isSponsored && !isPremium && !gamDisabledByAlias)
+              >
                 <@header>More in ${content.primarySection.name}</@header>
                 <@query-params excludeContentIds=[content.id] />
               </global-section-feed-wrapper>
@@ -77,7 +85,14 @@ $ const loadMore = defaultValue(input.loadMore, true);
     </if>
     <if(withAds)>
       <marko-web-resolve-page|{ data: content }| node=pageNode>
-        <theme-fixed-ad-bottom aliases=hierarchyAliases(content.primarySection) />
+        $ const aliases = hierarchyAliases(content.primarySection);
+        $ const labels = getAsArray(content, "labels");
+        $ const isSponsored = labels.includes("Sponsored");
+        $ const isPremium = labels.includes('Premium');
+        $ const gamDisabledByAlias = getAsArray(GAM, "disableOnAliases").some((alias) => aliases.includes(alias));
+        <if(!isSponsored && !isPremium && !gamDisabledByAlias)>
+          <theme-fixed-ad-bottom aliases=hierarchyAliases(content.primarySection) />
+        </if>
       </marko-web-resolve-page>
     </if>
   </@below-page>

--- a/packages/global/components/layouts/content/wrapper.marko
+++ b/packages/global/components/layouts/content/wrapper.marko
@@ -68,9 +68,9 @@ $ const loadMore = defaultValue(input.loadMore, true);
       </marko-web-page-container>
     </if>
     <if(withAds)>
-    <marko-web-resolve-page|{ data: content }| node=pageNode>
-      <theme-fixed-ad-bottom aliases=hierarchyAliases(content.primarySection) />
-    </marko-web-resolve-page>
-  </if>
+      <marko-web-resolve-page|{ data: content }| node=pageNode>
+        <theme-fixed-ad-bottom aliases=hierarchyAliases(content.primarySection) />
+      </marko-web-resolve-page>
+    </if>
   </@below-page>
 </theme-content-page>

--- a/packages/global/components/layouts/content/wrapper.marko
+++ b/packages/global/components/layouts/content/wrapper.marko
@@ -22,14 +22,22 @@ $ const loadMore = defaultValue(input.loadMore, true);
   <if(GAM.enableRevealAd && withAds)>
     <@above-container>
       <marko-web-resolve-page|{ data: content }| node=pageNode>
+        <!-- Get and handle conent labels -->
+        $ const labels = getAsArray(content, "labels");
+        $ const isSponsored = labels.includes("Sponsored");
+        $ const isPremium = labels.includes('Premium');
         $ const aliases = hierarchyAliases(content.primarySection);
-        <global-reveal-ad-handler select-all-targets=true path=GAM.getAdUnit({ name: "reskin", aliases }).path id="reveal-ad" />
-        <theme-gam-define-display-ad
-          name="reskin-mobile"
-          position="content_page"
-          aliases=aliases
-          modifiers=["inter-block"]
-        />
+        <!-- for now only do something special with content primaried here -->
+        $ const gamDisabledByAlias = getAsArray(GAM, "disableOnAliases").some((alias) => aliases.includes(alias));
+        <if(withAds && !isSponsored && !isPremium && !gamDisabledByAlias)>
+          <global-reveal-ad-handler select-all-targets=true path=GAM.getAdUnit({ name: "reskin", aliases }).path id="reveal-ad" />
+          <theme-gam-define-display-ad
+            name="reskin-mobile"
+            position="content_page"
+            aliases=aliases
+            modifiers=["inter-block"]
+          />
+        </if>
       </marko-web-resolve-page>
     </@above-container>
   </if>

--- a/packages/global/components/layouts/content/wrapper.marko
+++ b/packages/global/components/layouts/content/wrapper.marko
@@ -48,24 +48,6 @@ $ const loadMore = defaultValue(input.loadMore, true);
             />
           </@section>
         </for>
-
-        <@section>
-          <if(withAds)>
-            <theme-gam-define-display-ad
-              name="reskin-mobile"
-              position="content_page"
-              aliases=aliases
-              modifiers=["inter-block"]
-            />
-          </if><if(withAds)>
-            <theme-gam-define-display-ad
-              name="reskin-mobile"
-              position="content_page"
-              aliases=aliases
-              modifiers=["inter-block"]
-            />
-          </if>
-        </@section>
       </marko-web-page-wrapper>
     </marko-web-resolve-page>
   </@page>

--- a/packages/global/components/layouts/website-section/default.marko
+++ b/packages/global/components/layouts/website-section/default.marko
@@ -19,19 +19,27 @@ $ const { GAM } = out.global;
     <@above-container>
       <marko-web-resolve-page|{ data: section }| node=pageNode>
         $ const aliases = hierarchyAliases(section);
-        <global-reveal-ad-handler select-all-targets=true path=GAM.getAdUnit({ name: "reskin", aliases }).path id="reveal-ad" />
-        <theme-gam-define-display-ad
-          name="reskin-mobile"
-          position="section_page"
-          aliases=aliases
-          modifiers=["inter-block"]
-        />
+        <!-- for now only do something special with content primaried here -->
+        $ const gamDisabledByAlias = getAsArray(GAM, "disableOnAliases").some((alias) => aliases.includes(alias));
+        <if(!gamDisabledByAlias)>
+          $ const aliases = hierarchyAliases(section);
+          <global-reveal-ad-handler select-all-targets=true path=GAM.getAdUnit({ name: "reskin", aliases }).path id="reveal-ad" />
+          <theme-gam-define-display-ad
+            name="reskin-mobile"
+            position="section_page"
+            aliases=aliases
+            modifiers=["inter-block"]
+          />
+        </if>
       </marko-web-resolve-page>
     </@above-container>
   </if>
   <@page>
     <marko-web-resolve-page|{ data: section }| node=pageNode>
       $ const aliases = hierarchyAliases(section);
+      <!-- for now only do something special with content primaried here -->
+      $ const gamDisabledByAlias = getAsArray(GAM, "disableOnAliases").some((alias) => aliases.includes(alias));
+      $ console.log('add section special logic here: ', section);
       <marko-web-page-wrapper>
         <for|s| of=sections>
           <@section|{ blockName }| modifiers=s.modifiers>
@@ -39,6 +47,7 @@ $ const { GAM } = out.global;
               block-name=blockName
               section=section
               aliases=aliases
+              with-ads=!gamDisabledByAlias
             />
           </@section>
         </for>
@@ -47,7 +56,12 @@ $ const { GAM } = out.global;
   </@page>
   <@foot>
     <marko-web-resolve-page|{ data: section }| node=pageNode>
-      <theme-fixed-ad-bottom aliases=hierarchyAliases(section) />
+      $ const aliases = hierarchyAliases(section);
+      <!-- for now only do something special with content primaried here -->
+      $ const gamDisabledByAlias = getAsArray(GAM, "disableOnAliases").some((alias) => aliases.includes(alias));
+      <if(!gamDisabledByAlias)>
+        <theme-fixed-ad-bottom aliases=aliases />
+      </if>
     </marko-web-resolve-page>
   </@foot>
 </theme-website-section-page>

--- a/packages/global/components/layouts/website-section/feed.marko
+++ b/packages/global/components/layouts/website-section/feed.marko
@@ -1,3 +1,4 @@
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 import { getAsArray } from "@parameter1/base-cms-object-path";
 
 $ const { id, alias, name, pageNode } = input;
@@ -31,7 +32,7 @@ $ const perPage = 12;
     />
   </@section> -->
 
-  <@section|{ blockName, section, aliases }|>
+  <@section|{ blockName, section, aliases, withAds }|>
     <if(input.beforeName)>
       <${input.beforeName}
         aliases=aliases
@@ -58,7 +59,7 @@ $ const perPage = 12;
       alias=alias
       display-pinned-content=input.displayPinnedContent
       flow=input.feedFlow
-      with-ads=input.withAds
+      with-ads=withAds
       query-params=input.queryParams
       above-the-fold=true
       ad-name=input.adName

--- a/packages/global/config/gam.js
+++ b/packages/global/config/gam.js
@@ -8,6 +8,11 @@ module.exports = ({
 
   config.enableRevealAd = false;
 
+  // should disable all ads on this section/children & content primaried to them
+  config.disableOnAliases = [
+    'resources/webinars',
+  ];
+
   config
     .setTemplate('LB-STICKY-BOTTOM', {
       size: [

--- a/packages/global/scss/components/_reveal-ad.scss
+++ b/packages/global/scss/components/_reveal-ad.scss
@@ -1,0 +1,40 @@
+/*! critical:start */
+@import "@parameter1/base-cms-marko-web-reveal-ad/scss/reveal-ad";
+@import "@parameter1/base-cms-marko-web-theme-monorail/scss/components/reveal-ad";
+/*! critical:end */
+/*! critical:start */
+/*! purgecss start ignore */
+// only apply the default margin top when ad is requested on page.
+body .document-container>.page:first-of-type {
+  margin-top: 0;
+}
+body .ad-container--template-reskin-mobile + .document-container >  .page:first-of-type {
+  margin-top: 298px;
+}
+body .ad-container--template-reskin-mobile + .document-container > .reveal-ad + .page:first-of-type {
+  margin-top: 0;
+}
+
+// Prevent Reveal Ad from causing CLS
+// @TODO determin if this should be moved to @parameter1/base-cms-marko-web
+#marko-web-reveal-ad-handler {
+  display: none;
+}
+.reveal-ad {
+  height: 298px;
+  overflow: hidden;
+}
+body .ad-container--template-reskin-mobile {
+  // prevent layout shift & add 20px mb (298px + 20px)
+  display: none;
+  @media (max-width: 750px) {
+    min-height: 318px;
+    display: block;
+    &+ .document-container > .page:first-of-type {
+      margin-top: 0;
+    }
+  }
+}
+
+/*! purgecss end ignore */
+/*! critical:end */

--- a/packages/global/scss/core.scss
+++ b/packages/global/scss/core.scss
@@ -710,31 +710,6 @@ label {
 /*! critical:end */
 
 /*! critical:start */
-/*! purgecss start ignore */
-// Prevent Reveal Ad from causing CLS
-// @TODO determin if this should be moved to @parameter1/base-cms-marko-web
-#marko-web-reveal-ad-handler {
-  display: none;
-}
-.reveal-ad {
-  height: 298px;
-  overflow: hidden;
-}
-body .ad-container--template-reskin-mobile {
-  // prevent layout shift & add 20px mb (298px + 20px)
-  display: none;
-  @media (max-width: 750px) {
-    min-height: 318px;
-    display: block;
-    &+ .document-container > .page:first-of-type {
-      margin-top: 0;
-    }
-  }
-}
-/*! purgecss end ignore */
-/*! critical:end */
-
-/*! critical:start */
 .site-menu {
   $self: &;
   top: $theme-site-navbar-logo-height-sm;

--- a/packages/global/templates/directory/index.marko
+++ b/packages/global/templates/directory/index.marko
@@ -19,20 +19,6 @@ $ const currentPage = search.getCurrentPage();
     </marko-web-resolve-page>
     <${input.head} />
   </@head>
-  <if(GAM.enableRevealAd)>
-    <@above-container>
-      <marko-web-resolve-page|{ data: section }| node=pageNode>
-        $ const aliases = hierarchyAliases(section);
-        <global-reveal-ad-handler select-all-targets=true path=GAM.getAdUnit({ name: "reskin", aliases }).path id="reveal-ad" />
-        <theme-gam-define-display-ad
-          name="reskin-mobile"
-          position="section_page"
-          aliases=aliases
-          modifiers=["inter-block"]
-        />
-      </marko-web-resolve-page>
-    </@above-container>
-  </if>
   <@page>
     <marko-web-resolve-page|{ data: section }| node=pageNode>
       $ const aliases = hierarchyAliases(section);

--- a/sites/auntminnie.com/server/styles/index.scss
+++ b/sites/auntminnie.com/server/styles/index.scss
@@ -11,10 +11,8 @@ $primary: #01274b;
 
 @import "@science-medicine-group/package-global/scss/core";
 /*! critical:start */
-@import "@parameter1/base-cms-marko-web-reveal-ad/scss/reveal-ad";
-@import "@parameter1/base-cms-marko-web-theme-monorail/scss/components/reveal-ad";
+@import "@science-medicine-group/package-global/scss/components/reveal-ad";
 /*! critical:end */
-
 .site-footer {
   &__logo {
     filter: none;

--- a/sites/auntminnieasia.com/server/styles/index.scss
+++ b/sites/auntminnieasia.com/server/styles/index.scss
@@ -11,6 +11,5 @@ $primary: #01274b;
 
 @import "@science-medicine-group/package-global/scss/core";
 /*! critical:start */
-@import "@parameter1/base-cms-marko-web-reveal-ad/scss/reveal-ad";
-@import "@parameter1/base-cms-marko-web-theme-monorail/scss/components/reveal-ad";
+@import "@science-medicine-group/package-global/scss/components/reveal-ad";
 /*! critical:end */

--- a/sites/auntminnieeurope.com/server/styles/index.scss
+++ b/sites/auntminnieeurope.com/server/styles/index.scss
@@ -11,10 +11,8 @@ $primary: #01274b;
 
 @import "@science-medicine-group/package-global/scss/core";
 /*! critical:start */
-@import "@parameter1/base-cms-marko-web-reveal-ad/scss/reveal-ad";
-@import "@parameter1/base-cms-marko-web-theme-monorail/scss/components/reveal-ad";
+@import "@science-medicine-group/package-global/scss/components/reveal-ad";
 /*! critical:end */
-
 .site-footer {
   &__logo {
     filter: none;

--- a/sites/drbicuspid.com/server/styles/index.scss
+++ b/sites/drbicuspid.com/server/styles/index.scss
@@ -12,10 +12,8 @@ $red: #e31c3d;
 
 @import "@science-medicine-group/package-global/scss/core";
 /*! critical:start */
-@import "@parameter1/base-cms-marko-web-reveal-ad/scss/reveal-ad";
-@import "@parameter1/base-cms-marko-web-theme-monorail/scss/components/reveal-ad";
+@import "@science-medicine-group/package-global/scss/components/reveal-ad";
 /*! critical:end */
-
 /*! critical:start */
 .site-navbar {
   &__logo {

--- a/sites/labpulse.com/server/styles/index.scss
+++ b/sites/labpulse.com/server/styles/index.scss
@@ -10,6 +10,5 @@ $primary: #1378a9;
 
 @import "@science-medicine-group/package-global/scss/core";
 /*! critical:start */
-@import "@parameter1/base-cms-marko-web-reveal-ad/scss/reveal-ad";
-@import "@parameter1/base-cms-marko-web-theme-monorail/scss/components/reveal-ad";
+@import "@science-medicine-group/package-global/scss/components/reveal-ad";
 /*! critical:end */


### PR DESCRIPTION
The css changes is so that the reveal css is all loaded in at the same place within the sites and so it is loaded in the correct sequence for the targeting to work correctly.  

@TODO: Determine the correct way to prevent ads from showing on a specific section & conditionally on a set of content.  