### PR TITLE
Add padding and border-radius to content-page-gate

### DIFF
--- a/packages/global/scss/components/user.scss
+++ b/packages/global/scss/components/user.scss
@@ -1,6 +1,8 @@
 .content-page-gate {
   $self: &;
 
+  padding: 20px;
+  border-radius: 10px;
   background-color: $gray-100;
 
   #{ $self }__title {


### PR DESCRIPTION
![Screenshot from 2024-04-02 13-47-38](https://github.com/parameter1/science-medicine-group-websites/assets/46794001/5a1fb611-96eb-4fc5-b000-afb366dc9bc7)
![Screenshot from 2024-04-02 13-47-46](https://github.com/parameter1/science-medicine-group-websites/assets/46794001/218ea697-cc0e-444c-ace0-abfb61c91c5d)
![Screenshot from 2024-04-02 13-48-02](https://github.com/parameter1/science-medicine-group-websites/assets/46794001/87d19e90-5a20-4d3e-bc04-38d749227724)
![Screenshot from 2024-04-02 13-48-11](https://github.com/parameter1/science-medicine-group-websites/assets/46794001/ba7f8c09-2f47-4cc0-ba87-dcf4fe17141e)
