### PR TITLE
Exclude ‘Company’ content types from ‘More in…’ block on homepage

### DIFF
--- a/packages/global/components/layouts/website-section/home.marko
+++ b/packages/global/components/layouts/website-section/home.marko
@@ -155,7 +155,6 @@ $ const promise = websiteSectionContentLoader(apollo, {
               </@section>
             </for>
             <@section|{ aliases }|>
-              $ const excludeContentTypes = ["Company"];
               <global-section-feed-wrapper aliases=aliases with-pagination=false>
                   <@header>${i18n("More from")} ${config.siteName()}</@header>
                   <@query-params
@@ -164,7 +163,7 @@ $ const promise = websiteSectionContentLoader(apollo, {
                     optionName=["Pinned", "Standard"]
                     excludeContentIds=sectionContent.ids
                     requires-image=true
-                    excludeContentTypes=excludeContentTypes
+                    excludeContentTypes="Company"
                   />
               </global-section-feed-wrapper>
             </@section>

--- a/packages/global/components/layouts/website-section/home.marko
+++ b/packages/global/components/layouts/website-section/home.marko
@@ -155,6 +155,7 @@ $ const promise = websiteSectionContentLoader(apollo, {
               </@section>
             </for>
             <@section|{ aliases }|>
+              $ const excludeContentTypes = ["Company"];
               <global-section-feed-wrapper aliases=aliases with-pagination=false>
                   <@header>${i18n("More from")} ${config.siteName()}</@header>
                   <@query-params
@@ -163,6 +164,7 @@ $ const promise = websiteSectionContentLoader(apollo, {
                     optionName=["Pinned", "Standard"]
                     excludeContentIds=sectionContent.ids
                     requires-image=true
+                    excludeContentTypes=excludeContentTypes
                   />
               </global-section-feed-wrapper>
             </@section>

--- a/packages/global/components/layouts/website-section/home.marko
+++ b/packages/global/components/layouts/website-section/home.marko
@@ -163,7 +163,7 @@ $ const promise = websiteSectionContentLoader(apollo, {
                     optionName=["Pinned", "Standard"]
                     excludeContentIds=sectionContent.ids
                     requires-image=true
-                    excludeContentTypes="Company"
+                    excludeContentTypes=["Company"]
                   />
               </global-section-feed-wrapper>
             </@section>


### PR DESCRIPTION
PROD:
<img width="1503" alt="Screenshot 2024-06-04 at 10 39 26 AM" src="https://github.com/parameter1/science-medicine-group-websites/assets/64623209/2fdb9538-1563-40aa-85f6-e0957e2efbf7">
DEV:
<img width="1591" alt="Screenshot 2024-06-04 at 10 39 33 AM" src="https://github.com/parameter1/science-medicine-group-websites/assets/64623209/891b1ae2-b899-4ea2-b95f-e97e5b595dce">
