### PR TITLE
Serve asset from cdn & ensure cdn is available to use in code

### DIFF
--- a/packages/global/templates/content/print.marko
+++ b/packages/global/templates/content/print.marko
@@ -10,15 +10,16 @@ $ const {
   site,
 } = out.global;
 
+$ const { cdn } = res.locals;
 $ const cardBlock = "content-page-card";
 $ const displayPublishedDate = ["event", "webinar", "contact", "company"].includes(type) ? false : true;
 
 <marko-web-document>
   <@head>
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-    <link rel="manifest" href="/site.webmanifest">
+    <link rel="apple-touch-icon" sizes="180x180" href=cdn.public("/apple-touch-icon.png")>
+    <link rel="icon" type="image/png" sizes="32x32" href=cdn.public("/favicon-32x32.png")>
+    <link rel="icon" type="image/png" sizes="16x16" href=cdn.public("/favicon-16x16.png")>
+    <link rel="manifest" href=cdn.public("/site.webmanifest")>
     <meta name="robots" content="noindex">
     <marko-web-content-page-metadata id=id />
 


### PR DESCRIPTION
<img width="2251" alt="Screenshot 2024-06-05 at 10 04 10 AM" src="https://github.com/parameter1/science-medicine-group-websites/assets/3845869/d714982e-ae19-429b-acec-c16d8056f510">
