### PR TITLE
Remove ‘extra’ ad call on mobile

### DIFF
--- a/packages/global/components/layouts/content/wrapper.marko
+++ b/packages/global/components/layouts/content/wrapper.marko
@@ -57,13 +57,6 @@ $ const loadMore = defaultValue(input.loadMore, true);
               aliases=aliases
               modifiers=["inter-block"]
             />
-          </if><if(withAds)>
-            <theme-gam-define-display-ad
-              name="reskin-mobile"
-              position="content_page"
-              aliases=aliases
-              modifiers=["inter-block"]
-            />
           </if>
         </@section>
       </marko-web-page-wrapper>


### PR DESCRIPTION
PRODUCTION:
<img width="633" alt="Screenshot 2024-06-24 at 10 04 44 AM" src="https://github.com/parameter1/science-medicine-group-websites/assets/64623209/286e247e-8392-4118-9850-0962544cff90">

DEV:
<img width="689" alt="Screenshot 2024-06-24 at 10 04 23 AM" src="https://github.com/parameter1/science-medicine-group-websites/assets/64623209/0c1a1f68-24ac-4f6c-a7ca-5dd59b6f1208">
