### PR TITLE
Always apply `last_email_activity_legacy` when utilizing trackUser, trackUser on login-link-sent 

### DIFF
--- a/packages/braze/hooks/on-login-link-sent.js
+++ b/packages/braze/hooks/on-login-link-sent.js
@@ -19,6 +19,10 @@ module.exports = async ({
   /** @type {IdentityXRequest} */
   const { braze } = service.req;
 
+  if (user) {
+    await braze.trackUser(user.email, user.id);
+  }
+
   if (user && !user.verified) {
     await braze.unconfirmUser(user.email, user.id);
     await braze.updateSubscriptions(user.email, user.id, { [brazeConfig.defaultGroupId]: true });

--- a/packages/braze/service.js
+++ b/packages/braze/service.js
@@ -69,9 +69,13 @@ class Braze {
    * @returns Object
    */
   async trackUser(email, externalId, payload = {}) {
+    const now = new Date();
+    const nowISOString = now.toISOString();
+    const [nowAsYYYYMMDD] = nowISOString && nowISOString.split('T').length ? nowISOString.split('T') : [];
     return this.request('users/track', {
       body: JSON.stringify({
         attributes: [{
+          ...(nowAsYYYYMMDD && { last_email_activity_legacy: nowAsYYYYMMDD }),
           ...payload,
           email,
           external_id: externalId,


### PR DESCRIPTION
Replicates https://github.com/parameter1/science-medicine-group-websites/pull/593 onto main branch.