### PR TITLE
Don't load modal on user or page routes

### DIFF
--- a/packages/global/components/document.marko
+++ b/packages/global/components/document.marko
@@ -90,7 +90,7 @@ $ const { gamDefer, gtmDefer, initOnly } = req.query;
       <!-- <theme-site-menu has-user=hasUser reg-enabled=isEnabled /> -->
     </marko-web-identity-x-context>
     $ const { enabled: modalEnabled } =  site.getAsObject("newsletter.modal");
-    <if(hasCookie && cookieValue === "1" && modalEnabled)>
+    <if(hasCookie && cookieValue === "1" && modalEnabled && !req.path.match(/^\/user|\/page/))>
       <global-newsletter-signup-modal-block />
     </if>
     <${input.aboveContainer} />


### PR DESCRIPTION
Missed via https://github.com/parameter1/science-medicine-group-websites/pull/599 as this is ultimately what triggers the "scroll lock" due to the modal loading, not necessarily whether or not it displays.