### PR TITLE
Add ‘Sponsor’ label to white paper layout

### DIFF
--- a/packages/global/components/layouts/content/whitepaper.marko
+++ b/packages/global/components/layouts/content/whitepaper.marko
@@ -12,6 +12,12 @@ $ const { id, type, pageNode, ...rest } = input;
 
   <@section|{ blockName, content, aliases }| modifiers=["content-header"]>
     $ const { primarySection } = content;
+    $ const isSponsored = getAsArray(content, "labels").includes("Sponsored");
+    <div class="content-page-header">
+      <if(isSponsored)>
+        <div class="content-page-sponsored-header mb-3">Sponsored</div>
+      </if>
+    </div>
     <div class="content-page-header content-page-header--full-width">
       <theme-content-page-breadcrumbs section=primarySection />
       <marko-web-content-name tag="h1" block-name=blockName obj=content />


### PR DESCRIPTION
<img width="1440" alt="Screenshot 2024-11-14 at 6 55 47 PM" src="https://github.com/user-attachments/assets/2956437c-1932-41c2-9a8b-25730327a0f6">
